### PR TITLE
Add option to providers 'Contain only'.

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -68,7 +68,7 @@ def search(payload, method="general"):
     available_providers = 0
     request_time = time.time()
 
-    providers = get_enabled_providers()
+    providers = get_enabled_providers(method)
 
     if len(providers) == 0:
         notify(translation(32060), image=get_icon_path())

--- a/burst/utils.py
+++ b/burst/utils.py
@@ -101,16 +101,25 @@ def get_providers():
     return results
 
 
-def get_enabled_providers():
+def get_enabled_providers(method):
     """ Utility method to get all enabled provider IDs
 
     Returns:
         list: All available enabled provider IDs
     """
     results = []
+    type = "2"
+    if method == "general":
+        type = "0"
+    elif method == "movie":
+        type = "1"
     for provider in definitions:
         if get_setting('use_%s' % provider, bool):
-            results.append(provider)
+            contains = get_setting('%s_contains' % provider, choices=('All', 'Movies', 'Serials'))
+            if contains == "0":
+                results.append(provider)
+            elif contains == type:
+                results.append(provider)
         if 'custom' in definitions[provider] and definitions[provider]['custom']:
             results.append(provider)
     return results

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -170,3 +170,19 @@ msgstr ""
 msgctxt "#32079"
 msgid "E-mail"
 msgstr ""
+
+msgctxt "#32080"
+msgid "Contains only"
+msgstr ""
+
+msgctxt "#32081"
+msgid "All"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Serials"
+msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -169,3 +169,19 @@ msgstr "Разрешать результаты без сидов"
 msgctxt "#32079"
 msgid "E-mail"
 msgstr ""
+
+msgctxt "#32080"
+msgid "Contains only"
+msgstr "Содержит"
+
+msgctxt "#32081"
+msgid "All"
+msgstr "Всё"
+
+msgctxt "#32082"
+msgid "Movies"
+msgstr "Фильмы"
+
+msgctxt "#32083"
+msgid "Serials"
+msgstr "Сериалы"

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -170,3 +170,19 @@ msgstr ""
 msgctxt "#32079"
 msgid "E-mail"
 msgstr ""
+
+msgctxt "#32080"
+msgid "Contains only"
+msgstr ""
+
+msgctxt "#32081"
+msgid "All"
+msgstr ""
+
+msgctxt "#32082"
+msgid "Movies"
+msgstr ""
+
+msgctxt "#32083"
+msgid "Serials"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -12,217 +12,274 @@
     <setting label="32012" type="lsep" />
     <setting label="YTS" id="use_yts" type="bool" default="true" />
       <setting id="yts_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="yts_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="RARBG" id="use_rarbg" type="bool" default="true" />
       <setting id="rarbg_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="rarbg_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="1337x" id="use_1337x" type="bool" default="true" />
       <setting id="1337x_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="1337x_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="TorLock" id="use_torlock" type="bool" default="true" />
       <setting id="torlock_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="torlock_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="MagnetDL" id="use_magnetdl" type="bool" default="true" />
       <setting id="magnetdl_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="magnetdl_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="The Pirate Bay" id="use_thepiratebay" type="bool" default="false" />
       <setting id="thepiratebay_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="thepiratebay_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Rutor" id="use_rutor" type="bool" default="false" />
       <setting id="rutor_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="rutor_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="MegaPeer" id="use_megapeer" type="bool" default="false" />
       <setting id="megapeer_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="megapeer_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Serialz.tv" id="use_serialz" type="bool" default="false" />
       <setting id="serialz_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="serialz_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="tfile.me" id="use_tfile" type="bool" default="false" />
       <setting id="tfile_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="tfile_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Kinozal" id="use_kinozal" type="bool" default="false" />
       <setting id="kinozal_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="kinozal_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Nextorrent" id="use_nextorrent" type="bool" default="false" />
       <setting id="nextorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="nextorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Torrent9" id="use_torrent9" type="bool" default="false" />
       <setting id="torrent9_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="torrent9_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Cpasbien" id="use_cpasbien" type="bool" default="false" />
       <setting id="cpasbien_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="cpasbien_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Nyaa" id="use_nyaa" type="bool" default="false" />
       <setting id="nyaa_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="nyaa_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="BTjunkie" id="use_btjunkie" type="bool" default="false" />
       <setting id="btjunkie_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="btjunkie_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Divxatope" id="use_divxatope" type="bool" default="false" />
       <setting id="divxatope_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="divxatope_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="TorrentFunk" id="use_torrentfunk" type="bool" default="false" />
       <setting id="torrentfunk_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="torrentfunk_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="idope" id="use_idope" type="bool" default="false" />
       <setting id="idope_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="idope_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="EZTV" id="use_eztv" type="bool" default="false" />
       <setting id="eztv_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="eztv_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="KickAss" id="use_kickass" type="bool" default="false" />
       <setting id="kickass_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="kickass_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="TorrentZ" id="use_torrentz" type="bool" default="false" />
       <setting id="torrentz_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="torrentz_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="EliteTorrent" id="use_elitetorrent" type="bool" default="false" />
       <setting id="elitetorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="elitetorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Bitsnoop" id="use_bitsnoop" type="bool" default="false" />
       <setting id="bitsnoop_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="bitsnoop_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="YourBitTorrent" id="use_yourbittorrent" type="bool" default="false" />
       <setting id="yourbittorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="yourbittorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Ilcorsaronero" id="use_ilcorsaronero" type="bool" default="false" />
       <setting id="ilcorsaronero_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="ilcorsaronero_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Monova" id="use_monova" type="bool" default="false" />
       <setting id="monova_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="monova_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Btstorrent" id="use_btstorrent" type="bool" default="false" />
       <setting id="btstorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="btstorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="GloTorrents" id="use_glotorrents" type="bool" default="false" />
       <setting id="glotorrents_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="glotorrents_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="ExtraTorrent" id="use_extratorrent" type="bool" default="false" />
       <setting id="extratorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="extratorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="TorrentDownloads" id="use_torrentdownloads" type="bool" default="false" />
       <setting id="torrentdownloads_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="torrentdownloads_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Zoogle" id="use_zoogle" type="bool" default="false" />
       <setting id="zoogle_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="zoogle_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="Zooqle" id="use_zooqle" type="bool" default="false" />
       <setting id="zooqle_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="zooqle_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="32014" type="lsep" />
     <setting label="TorrentLeech" id="use_torrentleech" type="bool" default="false" />
       <setting id="torrentleech_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="torrentleech_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="torrentleech_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="torrentleech_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="FileList" id="use_filelist" type="bool" default="false" />
       <setting id="filelist_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="filelist_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="filelist_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="filelist_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="T411" id="use_t411" type="bool" default="false" />
       <setting id="t411_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="t411_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="t411_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="t411_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="UHDBits" id="use_uhdbits" type="bool" default="false" />
       <setting id="uhdbits_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="uhdbits_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="uhdbits_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="uhdbits_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="AlphaReign" id="use_alphareign" type="bool" default="false" />
       <setting id="alphareign_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="alphareign_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="alphareign_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="alphareign_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="FinBytes" id="use_finbytes" type="bool" default="false" />
       <setting id="finbytes_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="finbytes_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="finbytes_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="finbytes_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="GimmePeers" id="use_gimmepeers" type="bool" default="false" />
       <setting id="gimmepeers_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="gimmepeers_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="gimmepeers_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="gimmepeers_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="Tv Torrents.ro" id="use_freshon.tv" type="bool" default="false" />
       <setting id="freshon.tv_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="freshon.tv_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="freshon.tv_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="freshon.tv_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="HD Torrents" id="use_hd-torrents" type="bool" default="false" />
       <setting id="hd-torrents_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="hd-torrents_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="hd-torrents_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="hd-torrents_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="XtremeZone" id="use_myxzorg" type="bool" default="false" />
       <setting id="myxzorg_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="myxzorg_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="myxzorg_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="myxzorg_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="Toloka" id="use_toloka" type="bool" default="false" />
       <setting id="toloka_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="toloka_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="toloka_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="toloka_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="0day" id="use_0day" type="bool" default="false" />
       <setting id="0day_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="0day_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="0day_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="0day_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="NewStudio" id="use_newstudio" type="bool" default="false" />
       <setting id="newstudio_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="newstudio_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="newstudio_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="newstudio_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="NNM-Club" id="use_nnmclub" type="bool" default="false" />
       <setting id="nnmclub_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="nnmclub_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="nnmclub_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="nnmclub_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="RuTracker" id="use_rutracker" type="bool" default="false" />
       <setting id="rutracker_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="rutracker_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="rutracker_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="rutracker_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="BaibaKo.TV" id="use_baibako" type="bool" default="false" />
       <setting id="baibako_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="baibako_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="baibako_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="baibako_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="torrent3d.ru" id="use_torrent3dru" type="bool" default="false" />
       <setting id="torrent3dru_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="torrent3dru_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="torrent3dru_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="torrent3dru_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="3d-tracker.ru" id="use_3dtrackerru" type="bool" default="false" />
       <setting id="3dtrackerru_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="3dtrackerru_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="3dtrackerru_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="3dtrackerru_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="nCore" id="use_ncore" type="bool" default="false" />
       <setting id="ncore_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="ncore_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="ncore_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="ncore_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="Rustorka" id="use_rustorka" type="bool" default="false" />
       <setting id="rustorka_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="rustorka_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="rustorka_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="rustorka_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="BlueBird" id="use_bluebird" type="bool" default="false" />
       <setting id="bluebird_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="bluebird_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="bluebird_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="bluebird_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="Yggtorrent" id="use_yggtorrent" type="bool" default="false" />
       <setting id="yggtorrent_username" label="32015" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="yggtorrent_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
+      <setting id="yggtorrent_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="yggtorrent_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
 
     <setting label="LostFilm.TV" id="use_lostfilm" type="bool" default="false" />
       <setting id="lostfilm_username" label="32079" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="lostfilm_password" label="32016" type="text" default="" option="hidden" subsetting="true" visible="eq(-2,true)" />
       <setting id="lostfilm_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-3,true)" />
+      <setting id="lostfilm_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-4,true)" />
   </category>
   <category label="32002">
     <setting label="4K/2160p" id="filter_4k" type="bool" default="true" />


### PR DESCRIPTION
Can select All, Movies or Serials
When burst takes from the settings included providers, we give him only those that are suitable for the query method.
This reduces the number of requests to sites, increases the search speed, because the script does not attempt to retrieve information from sites that the user has marked for another type of search
![default](https://user-images.githubusercontent.com/399013/34935033-480f7542-f9fe-11e7-8736-bda1af04e8fa.png)
