### PR TITLE
fixing Rutor Base URL

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -534,7 +534,7 @@
         "anime_extra": "",
         "anime_keywords": "{title} {episode}",
         "anime_query": "0/10/300/2/QUERYEXTRA",
-        "base_url": "http://rutor.info/search/",
+        "base_url": "http://new-rutor.org/search/",
         "public_dns_alias": "rutor.lib",
         "color": "FFFFDE00",
         "general_extra": "",


### PR DESCRIPTION
http://new-rutor.org/search/ is the correct URL for Rutor.
got it working again.