### PR TITLE
Improve 1337x parser

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -20,7 +20,7 @@
             "infohash": "",
             "name": "item('a', order=2)",
             "peers": "item(tag='td', order=3)",
-            "row": "find_once(tag='body').find_all('tr')",
+            "row": "find_once(tag='tbody').find_all('tr')",
             "seeds": "item(tag='td', order=2)",
             "size": "item(tag='td', order=5)",
             "torrent": "'https://www.1337x.to%s' % item(tag='a', attribute='href', order=2)"


### PR DESCRIPTION
Should be `<tbody>`, so that it only picks `<td>` elements (where the links are).
Currently it also picks the `<th>` element and always prints an "*** Empty name ***" message in the log for it.