### PR TITLE
rarbg season fallback needs leading zero

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -583,7 +583,7 @@
         "tv_extra2": null,
         "tv_keywords": "{title:original} s{season:2}e{episode:2}",
         "tv_keywords2": "{title:original} {season:2}x01|S{season:2}",
-        "tv_keywords_fallback": "{title:original} s{season}"
+        "tv_keywords_fallback": "{title:original} s{season:2}"
     },
     "rutor": {
         "enabled": true,


### PR DESCRIPTION
Hi
rarbg needs a leading zero for the season pack fallback. 
I tested it with a show called "The 100".
This probably applies to some other providers too but I have only tested rarbg.
