### PR TITLE
Linkomanija: change target from border to cell padding

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1049,7 +1049,7 @@
         "parser": {
             "name": "item(tag='a', order=2)",
             "peers": "item(tag='td', order=9)",
-            "row": "find_once('table', ('border', '1')).find_all('tr', start=2)",
+            "row": "find_once('table', ('cellpadding', '5')).find_all('tr', start=2)",
             "seeds": "item(tag='td', order=8)",
             "size": "item(tag='td', order=6)",
             "torrent": "'https://www.linkomanija.net/%s' % item(tag='a', attribute='href', select=('class', 'index'), order=1)"


### PR DESCRIPTION
During holidays in Linkomanija tracker there is a special event that enables freeleech. This creates a box on the results that announces the event.  Current implementation for the tracker treats the new table as the table with torrents. Therefore, burst returns 0 torrents for search query. The fix is to target the torrent table not by border but by padding.