### PR TITLE
py2_encode do not let generate hash on kodi 19

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -645,13 +645,9 @@ def cleanup_results(results_list):
                 if result['uri'] and result['uri'].startswith('magnet'):
                     hash_ = Magnet(result['uri']).info_hash.upper()
                 else:
-                    hash_ = result['uri']
+                    hash_ = py2_encode(result['uri'])
                     try:
                         hash_ = hash_.encode()
-                    except:
-                        pass
-                    try:
-                        hash_ = py2_encode(hash_)
                     except:
                         pass
                     hash_ = hashlib.md5(hash_).hexdigest()

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -645,7 +645,16 @@ def cleanup_results(results_list):
                 if result['uri'] and result['uri'].startswith('magnet'):
                     hash_ = Magnet(result['uri']).info_hash.upper()
                 else:
-                    hash_ = hashlib.md5(py2_encode(result['uri'])).hexdigest()
+                    hash_ = result['uri']
+                    try:
+                        hash_ = hash_.encode()
+                    except:
+                        pass
+                    try:
+                        hash_ = py2_encode(hash_)
+                    except:
+                        pass
+                    hash_ = hashlib.md5(hash_).hexdigest()
             except:
                 pass
         # try:


### PR DESCRIPTION
in kodi 19
`hashlib.md5()` throws TypeError when get unencoded `result['uri']`
and so for each result returns empty `hash_`
and because of that `filtered_list` contains only one (first) result with empty hash
but there are other different results but with empty hashes.

so, first do python 3 `encode()` (passed in kodi <19)
then `py2_encode()` for kodi <19 - `result['uri']` encoded, kodi 19 no changes
and we have encoded `result['uri']` on both versions and able to successfully generate hash