### PR TITLE
Fix for Python 3.9

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -14,7 +14,7 @@ from .normalize import normalize_string
 from .providers.definitions import definitions
 from .utils import Magnet, get_int, get_float, clean_number, size_int, get_alias
 if PY3:
-    from html.parser import HTMLParser
+    import html
     unicode = str
 else:
     from .parser.HTMLParser import HTMLParser
@@ -558,7 +558,11 @@ class Filtering:
             str: Converted string
         """
         name = name.replace('<![CDATA[', '').replace(']]', '')
-        name = HTMLParser().unescape(name.lower())
+
+        if PY3:
+            name = html.unescape(name.lower())
+        else:
+            name = HTMLParser().unescape(name.lower())
 
         return name
 

--- a/burst/normalize.py
+++ b/burst/normalize.py
@@ -15,8 +15,8 @@ import json
 import re
 import unicodedata
 if PY3:
+    import html
     from urllib.parse import unquote
-    from html.parser import HTMLParser
     unicode = str
 else:
     from urllib import unquote
@@ -185,7 +185,12 @@ def normalize_string(string, charset=None, replacing=False):
     string = fix_bad_unicode(string)
     string = unquote(string)
     string = string.replace(u'<![CDATA[', u'').replace(u']]', u'')
-    string = HTMLParser().unescape(string)
+
+    if PY3:
+        string = html.unescape(string)
+    else:
+        string = HTMLParser().unescape(string)
+
     if replacing:
         string = string.replace(u"'", '')
 


### PR DESCRIPTION
HTMLParser.unescape was removed from Python since version 3.9.0a1