### PR TITLE
Do not setup referer for requests

### DIFF
--- a/burst/client.py
+++ b/burst/client.py
@@ -266,7 +266,6 @@ class Client:
             'Cache-Control': 'max-age=0',
             'Content-Language': language,
             'Origin': url,
-            'Referer': url,
             'User-Agent': self.user_agent
         }
 


### PR DESCRIPTION
I found that requests to torrentapi (rarbg) fail with `Referer` set to any value. This pull request removes refererer for all requests since in current implementation it doesn't make much sense - referer shouldn't be the same page as the requested page (`'Referer': url`). I believe it doesn't affect other providers.

You can reproduce current behaviour of `torrentapi` it with curl:
* With referer (current implementation) it returns 429:
```curl 'https://torrentapi.org:443/pubapi_v2.php?get_token=get_token&app_id=script.elementum.burst' --header 'Referer: http://test.com'```
* Without referer it returns json with a token: 
```curl 'https://torrentapi.org:443/pubapi_v2.php?get_token=get_token&app_id=script.elementum.burst'```