### PR TITLE
Remove old messages

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -23,18 +23,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Općenito"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Izvori"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Razlučivost"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Vrste izdanja"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Napredno"
@@ -43,10 +31,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Filmovi"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "TV serije"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Sezone"
@@ -54,14 +38,6 @@ msgstr "Sezone"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Epizode"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Javni izvori"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Privatni izvori"
 
 msgctxt "#32015"
 msgid "Username"
@@ -113,10 +89,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Najviše rezultata po izvoru"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Koristi CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Iznimke"
@@ -153,10 +125,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Istek vremena mora biti manji od Elementumovog"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Nema pronađenih torrenta"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Lozinka"
@@ -168,10 +136,6 @@ msgstr "Naziv domene [neobavezno]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Dopusti rezultate bez dijelitelja"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr "E-pošta"
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -288,10 +252,6 @@ msgstr "Proxy iz Elementum postavki"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Prilagođene postavke"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Antizapret proxy"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr ""
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr ""
@@ -42,24 +30,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr ""
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr ""
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -285,10 +249,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Général"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Providers"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Résolutions"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Type de version"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avancé"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Films"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Series"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Saisons"
@@ -53,14 +37,6 @@ msgstr "Saisons"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Episodes"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Trackers publics"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Trackers privés"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Maximum de résultats par provider"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Utiliser CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Exceptions"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Le délai d'attente doit etre inférieure à celui de Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Pas de flux"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Allgemein"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Fortgeschritten"
@@ -42,24 +30,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "verwenden Sie CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Keine Torrents gefunden"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "כללי"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "ספקים"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "רזולוציות"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "סוגי הפצות"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "מתקדם"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "סרטים"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "סדרות"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "עונות"
@@ -53,14 +37,6 @@ msgstr "עונות"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "פרקים"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "טראקרים ציבוריים"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "טראקרים פרטיים"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "מקסימום תוצאות לספק"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "שימוש ב CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "חריגות"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "הגדרת מקסימום זמן לחיפוש חייבת להיות נמוכה יותר מאשר ההגדרה של Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "לא נמצאו טורנטים"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "מפתח"
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -21,18 +21,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Általános"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Kiszolgálók"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Felbontások"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Kiadási típusok"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Haladó"
@@ -41,10 +29,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Filmek"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Sorozatok"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Évadok"
@@ -52,14 +36,6 @@ msgstr "Évadok"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Epizódok"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Nyilvános trackerek"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Privát trackerek"
 
 msgctxt "#32015"
 msgid "Username"
@@ -109,10 +85,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Maximum találatok kiszolgálónként"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Használjon CloudHole-t"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Kivételek"
@@ -149,10 +121,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Az időkorlát beállításnak muszáj kisebbnek lennie a Elementum!"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Nincs találat"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Passkey"
@@ -163,10 +131,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -283,10 +247,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Generale"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Providers"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Risoluzioni"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Tipo release"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avanzato"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Film"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Programmi TV"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Stagioni"
@@ -53,14 +37,6 @@ msgstr "Stagioni"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Episodi"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Tracker pubblici"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Tracker privati"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Risultati massimi per provider"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Usa CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Eccezioni"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "L'impostazione del timeout deve essere inferiore a quella di Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Nessun torrent trovato"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Passkey"
@@ -165,10 +133,6 @@ msgstr "Alias Dominio [Opzionale]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Consenti risultati senza seeds"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr "E-mail"
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -285,10 +249,6 @@ msgstr "Proxy dalle impostazioni Elementum"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Impostazioni personalizzate"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Proxy Antizapret"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/Lithuania/strings.po
+++ b/resources/language/Lithuania/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Bendra"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Šaltiniai"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Kokybė"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Tipai"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Papildomai"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Filmai"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Serijalai"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Sezonai"
@@ -53,14 +37,6 @@ msgstr "Sezonai"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Epizodai"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Trakeriai laisvi"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Uždari trakeriai"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Maksimalūs rezultatas vienam teikėjui"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Naudoti CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Išimtys"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Nerasta nei vieno torrento"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Geral"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avançado"
@@ -42,24 +30,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Usar CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Não encontrou torrent"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Geral"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avançado"
@@ -42,24 +30,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Usar CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Não encontrou torrent"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Общие"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Провайдеры"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Качество"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Виды релиза"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Дополнительно"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Фильмы"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Сериалы"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Сезоны"
@@ -53,14 +37,6 @@ msgstr "Сезоны"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Эпизоды"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Открытые трекеры"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Закрытые трекеры"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Максимальное кол-во результатов для провайдера"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Использовать CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Исключения"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Значения тайм-аута должно быть меньше чем у Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Не найден ни один торрент"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -165,10 +133,6 @@ msgstr "Альтернативный домен [Опционально]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Разрешать результаты без сидов"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr ""
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -286,10 +250,6 @@ msgstr "Прокси из настроек Elementum"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Пользовательские настройки"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Прокси Antizapret"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Proveedores"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Resoluciones"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Tipos de releases"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avanzado"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Películas"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Series"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Temporadas"
@@ -53,14 +37,6 @@ msgstr "Temporadas"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Episodios"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Trackers públicos"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Trackers privados"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Cantidad máxima de resultados por proveedor"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Utilizar CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Excepciones"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Los ajustes de tiempo límite deben ser menores que los de Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "No se encontró ningún torrent"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Passkey"
@@ -165,10 +133,6 @@ msgstr "Alias dominio [Opcional]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Permitir resultados sin seeds"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr "E-mail"
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -285,10 +249,6 @@ msgstr "Usar proxy de ajuste Elementum"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Ajustes personalizados"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Proxy Antizapret"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avanzado"
@@ -42,24 +30,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Utilizar CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Ningún torrent encontrado"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "General"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Proveedores"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Resoluciones"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Tipos de versiones"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avanzado"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Películas"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Programas de TV"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Temporadas"
@@ -53,14 +37,6 @@ msgstr "Temporadas"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Episodios"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Trackers públicos"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Trackers privados"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Número máximo de resultados por proveedor"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Utilizar CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Exceptiones"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "El ajuste de tiempo de espera debe de ser inferior al de Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "No se encontraron torrents"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Clave de acceso"
@@ -165,10 +133,6 @@ msgstr "Alias de dominio [opcional]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Permitir resultados sin semillas"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr "E-mail"
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -285,10 +249,6 @@ msgstr "Elementum"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Personalizada"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Proxy Antizapret"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Allmänt"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Leverantörer"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Upplösningar"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Utgåvetyper"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Avancerat"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Filmer"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "TV-serier"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Säsonger"
@@ -53,14 +37,6 @@ msgstr "Säsonger"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Avsnitt"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Publika bevakare"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Privata bevakare"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Maximalt resultat per leverantör"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Använd CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Undantag"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Sluttidsinställningen måste vara lägre än Elementums"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Inga torrenter hittades"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr "Lösenord"
@@ -165,10 +133,6 @@ msgstr "Domänalias [Optional]"
 msgctxt "#32078"
 msgid "Allow results without seeds"
 msgstr "Tillåt resultat utan distribueringar"
-
-msgctxt "#32079"
-msgid "E-mail"
-msgstr "E-post"
 
 msgctxt "#32080"
 msgid "Contains only"
@@ -285,10 +249,6 @@ msgstr "Proxy från Elementum-inställningar"
 msgctxt "#32108"
 msgid "Custom settings"
 msgstr "Anpassade inställningar"
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
-msgstr "Antizapret-proxy"
 
 msgctxt "#32110"
 msgid "International"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -22,18 +22,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr "Загальні"
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr "Провайдери"
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr "Якість"
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr "Види релізу"
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr "Додатково"
@@ -42,10 +30,6 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr "Фільми"
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr "Серіали"
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr "Сезони"
@@ -53,14 +37,6 @@ msgstr "Сезони"
 msgctxt "#32009"
 msgid "Episodes"
 msgstr "Епізоди"
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr "Відкриті трекери"
-
-msgctxt "#32014"
-msgid "Private trackers"
-msgstr "Закриті трекери"
 
 msgctxt "#32015"
 msgid "Username"
@@ -110,10 +86,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr "Максимальна кіл-ть результатів для провайдера"
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr "Використовувати CloudHole"
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr "Виключення"
@@ -150,10 +122,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr "Значення тайм-ауту повино бути меншим ніж у Elementum"
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr "Не знайдено жодного торренту"
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -164,10 +132,6 @@ msgstr "Альтернативний домен [Опціонально]"
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -284,10 +248,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -23,18 +23,6 @@ msgctxt "#32000"
 msgid "General"
 msgstr ""
 
-msgctxt "#32001"
-msgid "Providers"
-msgstr ""
-
-msgctxt "#32002"
-msgid "Resolutions"
-msgstr ""
-
-msgctxt "#32003"
-msgid "Release types"
-msgstr ""
-
 msgctxt "#32004"
 msgid "Advanced"
 msgstr ""
@@ -43,24 +31,12 @@ msgctxt "#32006"
 msgid "Movies"
 msgstr ""
 
-msgctxt "#32007"
-msgid "TV Shows"
-msgstr ""
-
 msgctxt "#32008"
 msgid "Seasons"
 msgstr ""
 
 msgctxt "#32009"
 msgid "Episodes"
-msgstr ""
-
-msgctxt "#32012"
-msgid "Public trackers"
-msgstr ""
-
-msgctxt "#32014"
-msgid "Private trackers"
 msgstr ""
 
 msgctxt "#32015"
@@ -111,10 +87,6 @@ msgctxt "#32040"
 msgid "Maximum results per provider"
 msgstr ""
 
-msgctxt "#32041"
-msgid "Use CloudHole"
-msgstr ""
-
 msgctxt "#32050"
 msgid "Exceptions"
 msgstr ""
@@ -151,10 +123,6 @@ msgctxt "#32071"
 msgid "Timeout setting must be lower than Elementum's"
 msgstr ""
 
-msgctxt "#32075"
-msgid "No torrents found"
-msgstr ""
-
 msgctxt "#32076"
 msgid "Passkey"
 msgstr ""
@@ -165,10 +133,6 @@ msgstr ""
 
 msgctxt "#32078"
 msgid "Allow results without seeds"
-msgstr ""
-
-msgctxt "#32079"
-msgid "E-mail"
 msgstr ""
 
 msgctxt "#32080"
@@ -285,10 +249,6 @@ msgstr ""
 
 msgctxt "#32108"
 msgid "Custom settings"
-msgstr ""
-
-msgctxt "#32109"
-msgid "Antizapret proxy"
 msgstr ""
 
 msgctxt "#32110"

--- a/scripts/xgettext_remove_old_messages.sh
+++ b/scripts/xgettext_remove_old_messages.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+
+which rg > /dev/null || (echo "No ripgrep found, exit" && exit 1)
+
+grep -oP 'msgctxt "#\K\d+' resources/language/messages.pot > ids.pot
+
+while read -r line; do rg -q -g '!*.po' -g '!*.pot' $line . || echo $line; done < ids.pot > orphaned_ids.pot
+
+find resources/ -name "*.po*" |
+while read -r file
+do
+    while read -r line
+    do
+        sed -i "/$line/,+3d" "$file"
+    done < orphaned_ids.pot
+done
+
+# TODO: https://stackoverflow.com/questions/10435926/how-to-automatcially-remove-unused-gettext-strings/26469640
+# after cleaning pot file we can use msgattrib to clean po files
+# msgattrib --set-obsolete --ignore-file=messages.pot -o messages.po messages.po
+# msgattrib --no-obsolete -o messages.po messages.po
+
+rm -f ids.pot orphaned_ids.pot


### PR DESCRIPTION
Remove old messages and remove them from translations to make code cleaner and to ease work for translators.

tested on kodi 19 with ru lang.

