### PR TITLE
Fix remove accents for search

### DIFF
--- a/burst/normalize.py
+++ b/burst/normalize.py
@@ -68,7 +68,7 @@ def remove_accents(string):
         string = normalize_string(string)
 
     nfkd_form = unicodedata.normalize('NFKD', string)
-    only_ascii = py2_encode(nfkd_form, 'ASCII', 'ignore').strip()
+    only_ascii = nfkd_form.encode('ASCII', 'ignore').decode('ASCII', 'ignore').strip()
     return string if only_ascii == u'' else only_ascii
 
 


### PR DESCRIPTION
fixes https://github.com/elgatito/script.elementum.burst/issues/259

сломалось тут https://github.com/elgatito/script.elementum.burst/commit/34250fcc3b0512cf1eb7b531ede367a309fef3e4#diff-32510ac0dc8c58a043c69fa5408768bb28ea2e13b74bea5639c654aa121c33dbR69

в данном случае encode() используется не для конвертации строки в строку/байты, как обычно в контексте py2/py3, а для удаления accents.

проверено на русском и французском.

выглядит примерно так

![image](https://user-images.githubusercontent.com/17964763/111757433-6084cb00-88ac-11eb-835c-ad5561462813.png)


проверено на kodi 17/19