### PR TITLE
add support of _fallback_extra

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -57,6 +57,7 @@ class Filtering:
             engine when no results are found (ie. TorLock and TorrentZ)
         queries (list): List of queries to be filtered
         extras (list): List of extras to be filtered
+        queries_priorities (list): Priorities of the queries
         info (dict): Payload from Elementum
         kodi_language (str): Language code from Kodi if kodi_language setting is enabled
         language_exceptions (list): List of providers for which not to apply ``kodi_language`` setting
@@ -178,6 +179,7 @@ class Filtering:
 
         self.queries = []
         self.extras = []
+        self.queries_priorities = []
 
         self.info = dict(title="", proxy_url="", internal_proxy_url="", elementum_url="", titles=[])
         self.kodi_language = ''
@@ -333,25 +335,30 @@ class Filtering:
 
     def collect_queries(self, item_type, definition):
         # Collecting keywords
+        priority = 1
         for item in ['', '2', '3', '4']:
             key = item_type + '_keywords' + item
             extra = item_type + '_extra' + item
             if key in definition and definition[key]:
                 qlist = self.split_title_per_languages(definition[key], item_type)
-                self.queries = self.queries + qlist
+                self.queries.extend(qlist)
                 eitem = definition[extra] if extra in definition and definition[extra] else ''
-                for r in qlist:
+                for _ in qlist:
                     self.extras.append(eitem)
+                    self.queries_priorities.append(priority)
 
         # Collecting fallback keywords, they will come in play if having no results at all
         for item in ['', '2', '3', '4']:
             key = item_type + '_keywords_fallback' + item
-
+            extra = item_type + '_fallback_extra' + item
             if key in definition and definition[key]:
                 qlist = self.split_title_per_languages(definition[key], item_type)
-                self.queries = self.queries + qlist
-                for r in qlist:
-                    self.extras.append('-')
+                self.queries.extend(qlist)
+                eitem = definition[extra] if extra in definition and definition[extra] else ''
+                for _ in qlist:
+                    priority += 1
+                    self.extras.append(eitem)
+                    self.queries_priorities.append(priority)
 
     def information(self, provider):
         """ Debugging method to print keywords and file sizes

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -350,7 +350,7 @@ class Filtering:
         # Collecting fallback keywords, they will come in play if having no results at all
         for item in ['', '2', '3', '4']:
             key = item_type + '_keywords_fallback' + item
-            extra = item_type + '_fallback_extra' + item
+            extra = item_type + '_extra_fallback' + item
             if key in definition and definition[key]:
                 qlist = self.split_title_per_languages(definition[key], item_type)
                 self.queries.extend(qlist)

--- a/burst/provider.py
+++ b/burst/provider.py
@@ -91,7 +91,7 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
     token = None
     logged_in = False
     token_auth = False
-    used_queries = []
+    used_queries = set()
 
     if get_setting('kodi_language', bool):
         kodi_language = xbmc.getLanguage(xbmc.ISO_639_1)
@@ -104,7 +104,8 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
     log.debug("[%s] Queries: %s" % (provider, filtering.queries))
     log.debug("[%s] Extras:  %s" % (provider, filtering.extras))
 
-    for query, extra in zip(filtering.queries, filtering.extras):
+    last_priority = 1
+    for query, extra, priority in zip(filtering.queries, filtering.extras, filtering.queries_priorities):
         log.debug("[%s] Before keywords - Query: %s - Extra: %s" % (provider, repr(query), repr(extra)))
         if has_special:
             # Removing quotes, surrounding {title*} keywords, when title contains special chars
@@ -115,16 +116,18 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
 
         if not query:
             continue
-        elif query in used_queries:
+        elif query+extra in used_queries:
             # Make sure we don't run same query for this provider
             continue
-        elif extra == '-' and filtering.results:
+        elif priority > last_priority and filtering.results:
+            # Skip fallbacks if there are results
             continue
         elif start_time and timeout and time.time() - start_time + 3 >= timeout:
             # Stop doing requests if there is 3 seconds left for the overall task
             continue
 
-        used_queries.append(query)
+        used_queries.add(query+extra)
+        last_priority = priority
 
         try:
             if 'charset' in definition and definition['charset'] and 'utf' not in definition['charset'].lower():
@@ -142,7 +145,7 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
             return filtering.results
 
         url_search = filtering.url.replace('QUERY', query)
-        if extra and extra != '-':
+        if extra:
             url_search = url_search.replace('EXTRA', extra)
         else:
             url_search = url_search.replace('EXTRA', '')

--- a/burst/provider.py
+++ b/burst/provider.py
@@ -121,6 +121,7 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
             continue
         elif priority > last_priority and filtering.results:
             # Skip fallbacks if there are results
+            log.debug("[%s] Skip fallback as there are already results" % provider)
             continue
         elif start_time and timeout and time.time() - start_time + 3 >= timeout:
             # Stop doing requests if there is 3 seconds left for the overall task


### PR DESCRIPTION
добавил `*_extra` для `*_keywords_fallback`, например для поиска в другой категории:
например, сначала ищем сериал в категории сериалы в основных `*_keywords`, 
а потом ищем сериал в категории мультфильмы в `*_keywords_fallback` - чтобы не искать сразу в 2х категориях.
соответственно используем `*_extra` как указатель на категорию, a категорию определяем в `*_query` как `EXTRA`.

ниже есть примеры использования.