### PR TITLE
Use remove_special_characters in rutor and thepiratebay

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1677,6 +1677,7 @@
         "predefined": false,
         "private": false,
         "public_dns_alias": "rutor.lib",
+        "remove_special_characters" : "'",
         "season_query": "0/EXTRA/300/2/QUERY",
         "season_keywords": "{title:en:ru} {season:2}x01|(01-{season:2}x01)|S{season:2}|(S01-{season:2})",
         "season_extra": "4",

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1957,6 +1957,7 @@
         },
         "predefined": false,
         "private": false,
+        "remove_special_characters" : "'",
         "season_extra": "",
         "season_extra2": "",
         "season_keywords": "{title:en} season {season:2}",


### PR DESCRIPTION
Use remove_special_characters in rutor and thepiratebay - see https://github.com/elgatito/script.elementum.burst/issues/263