### PR TITLE
use language in remove_accents

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -426,7 +426,7 @@ class Filtering:
                             title = normalize_string(title)
                             # For all non-original titles, try to remove accents from the title.
                             if use_language != 'original':
-                                title = remove_accents(title)
+                                title = remove_accents(title, use_language)
                             # Remove characters, filled in 'remove_special_characters' field definition.
                             if 'remove_special_characters' in definition and definition['remove_special_characters']:
                                 for char in definition['remove_special_characters']:

--- a/burst/normalize.py
+++ b/burst/normalize.py
@@ -39,36 +39,48 @@ def clean_title(string=None):
     return string
 
 
-def are_equals(string_1='', string_2=''):
+def are_equals(string_1, string_2, language):
     """
         Checks if the two string are equals even without accents
     :param string_1: first string
     :type: string_1: unicode
     :param string_2: second string
     :type: string_2: unicode
+    :param language: language of the strings
+    :type language: str or unicode
     :return: True if it is equal, False otherwise
     :rtype: bool
     """
     string_1 = safe_name(string_1)
     string_2 = safe_name(string_2)
-    string_a = remove_accents(string_1)
-    string_b = remove_accents(string_2)
+    string_a = remove_accents(string_1, language)
+    string_b = remove_accents(string_2, language)
     return any([string_1 == string_2, string_a == string_b])
 
 
-def remove_accents(string):
+def remove_accents(string, language):
     """
         Remove any accent in the string
     :param string: string to remove accents
     :type string: str or unicode
+    :param language: language of the string
+    :type language: str or unicode
     :return: string without accents
     :rtype: unicode
     """
     if not isinstance(string, unicode):
         string = normalize_string(string)
 
+    encoding = 'ASCII'
+    if language in ('by', 'ua', 'ru'):
+        #encoding = 'cp1251' # whis would help to handle mixed languages string (e.g en+ua or fr+ru)
+        # but we don't want to remove accents for these langs, since their "accents" are not really accents
+        # see https://github.com/elgatito/script.elementum.burst/issues/259 for more details
+        return string
+    # for other languages contributors can add appropriate encoding to be able properly handle mixed languages string
+
     nfkd_form = unicodedata.normalize('NFKD', string)
-    only_ascii = nfkd_form.encode('ASCII', 'ignore').decode('ASCII', 'ignore').strip()
+    only_ascii = nfkd_form.encode(encoding, 'ignore').decode(encoding, 'ignore').strip()
     # for non-ASCII language we can end up with string like ": , ." so we should not use it
     only_ascii_is_empty = u''.join([char for char in only_ascii if char.isalpha()]) == u''
     return string if only_ascii_is_empty else only_ascii


### PR DESCRIPTION
узнать, что в строке есть "Диакритические знаки" и при этом, что она не смесь языков у меня не получилось:
1. так как если удалить сперва всё что не буквы, а потом проверить не стало ли меньше при конвертации в ascii не выйдет, так как уменьшение будет и для диакритиков и для не латинских букв. 
2. а если проверять не увеличился ли размер после конвертации в NFKD, то косяк в том, что нам может придти изначально NFKD, ну и любая простая строка аля abc тоже считается NFKD (нельзя проверить что пришла именно NFKD и тогда не надо сравнивать размер), так как NFKD это форма, а не кодировка. Плюс ещё и кириллические йёїў тоже будут считаться диакритиками и увеличивать размер, а конвертировать их плохо, так как не все трекеры считают например `и` и `й` одинаковой буквой.

в общем, ед хороший вариант - это либо определять по языку кодировку и использовать её вместо ascii, либо не делать преобразование вообще для языков для которых это вредно (by/ua/ru).

соотв в PR смесь этих двух подходов.

fix https://github.com/elgatito/script.elementum.burst/issues/283