### PR TITLE
Proxy settings fixes

### DIFF
--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr "Koristi proxy postavke"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr "Proxy iz Elementum postavki"
 
 msgctxt "#32108"

--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -353,3 +353,19 @@ msgstr "Video kvaliteta"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"
@@ -352,4 +352,20 @@ msgstr ""
 
 msgctxt "#32135"
 msgid "Belarusian"
+msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
 msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -242,7 +242,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -352,3 +352,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr "Usa le impostazioni proxy"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr "Proxy dalle impostazioni Elementum"
 
 msgctxt "#32108"

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -353,3 +353,19 @@ msgstr "Qualità video"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Lithuania/strings.po
+++ b/resources/language/Lithuania/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Lithuania/strings.po
+++ b/resources/language/Lithuania/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -354,6 +354,14 @@ msgctxt "#32135"
 msgid "Belarusian"
 msgstr "Белорусский"
 
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
 msgctxt "#32138"
 msgid "From Elementum settings (resolve hosts by proxy)"
 msgstr "Из настроек Elementum (разрешать имена на прокси)"

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -243,8 +243,8 @@ msgid "Use proxy settings"
 msgstr "Вид настроек прокси"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
-msgstr "Прокси из настроек Elementum"
+msgid "From Elementum settings"
+msgstr "Из настроек Elementum"
 
 msgctxt "#32108"
 msgid "Custom settings"
@@ -353,3 +353,11 @@ msgstr "Качество видео"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr "Белорусский"
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr "Из настроек Elementum (разрешать имена на прокси)"
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr "Сперва включите встроенный HTTP прокси в Elementum"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr "Usar configuración de proxy"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr "Usar proxy de ajuste Elementum"
 
 msgctxt "#32108"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -353,3 +353,19 @@ msgstr "Calidad de video"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr "Usar configuración"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr "Elementum"
 
 msgctxt "#32108"

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -353,3 +353,19 @@ msgstr "Calidad de vídeo"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr "Använd proxyinställningar"
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr "Proxy från Elementum-inställningar"
 
 msgctxt "#32108"

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -353,3 +353,19 @@ msgstr "Videokvalitét"
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -243,7 +243,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -353,3 +353,19 @@ msgstr ""
 msgctxt "#32135"
 msgid "Belarusian"
 msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
+msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -244,7 +244,7 @@ msgid "Use proxy settings"
 msgstr ""
 
 msgctxt "#32107"
-msgid "Proxy from Elementum settings"
+msgid "From Elementum settings"
 msgstr ""
 
 msgctxt "#32108"
@@ -353,4 +353,20 @@ msgstr ""
 
 msgctxt "#32135"
 msgid "Belarusian"
+msgstr ""
+
+msgctxt "#32136"
+msgid "SOCKS4a"
+msgstr ""
+
+msgctxt "#32137"
+msgid "SOCKS5h"
+msgstr ""
+
+msgctxt "#32138"
+msgid "From Elementum settings (resolve hosts by proxy)"
+msgstr ""
+
+msgctxt "#32139"
+msgid "First enable built-in HTTP proxy in Elementum"
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,6 +3,7 @@
   <!-- General -->
   <category label="32000">
     <setting label="32125" id="use_elementum_proxy" type="bool" default="true" />
+    <setting id="elementum_proxy_help" label="32139" type="text" enable="false" subsetting="true" />
 
     <setting label="32084" id="use_public_dns" type="bool" default="false" enable="eq(-1,false)" />
       <setting id="public_dns_list" label="32093" type="text" default="8.8.8.8, 8.8.4.4, 9.9.9.9" enable="eq(-1,true) + eq(-2,false)" />
@@ -389,8 +390,8 @@
   <category label="32095">
       <setting label="32095" type="lsep" />
       <setting id="proxy_enabled" label="32096" type="bool" default="false" />
-        <setting id="proxy_use_type" label="32106" type="enum" default="0" subsetting="true" lvalues="32107|32108" enable="eq(-1,true)" />
-        <setting id="proxy_type" label="32101" type="enum" default="1" subsetting="true" lvalues="32102|32103|32104|32105" enable="eq(-1,1)" />
+        <setting id="proxy_use_type" label="32106" type="enum" default="2" subsetting="true" lvalues="32107|32108|32138" enable="eq(-1,true)" />
+        <setting id="proxy_type" label="32101" type="enum" default="5" subsetting="true" lvalues="32102|32103|32104|32105|32136|32137" enable="eq(-1,1)" />
         <setting id="proxy_host" label="32097" type="text" default="" subsetting="true" enable="eq(-2,1)" />
         <setting id="proxy_port" label="32098" type="number" default="1080" subsetting="true" enable="eq(-3,1)" />
         <setting id="proxy_login" label="32099" type="text" default="" subsetting="true" enable="eq(-4,1)" />


### PR DESCRIPTION
- Fixes `Proxy from Elementum settings` setting

Log reported setting applied without really doing anything.

- Adds `Proxy from Elementum (resolve hosts by proxy)` setting option

Option enables default behaviour of `Elementum` in `Burst`. Option is set as new default,
existing users should not be affected by change.

- Adds choice of additional proxy protocols in settings

`SOCKS4a` (`SOCKS4` latest version with hostname resolve by proxy)
`SOCKS5h` (`SOCKS5` latest version with hostname resolve by proxy). Protocol is set as new
default to match default setting in `Elementum`, existing users should not be affected by
change.

- Adds help label for `use_elementum_proxy` setting