### PR TITLE
Cleanup results before adding to the result list

### DIFF
--- a/burst/provider.py
+++ b/burst/provider.py
@@ -13,6 +13,7 @@ import time
 import urllib
 from .client import Client
 from elementum.provider import log, get_setting, set_setting
+from .filtering import cleanup_results
 from .providers.definitions import definitions, longest
 from .utils import ADDON_PATH, get_int, clean_size, get_alias
 from kodi_six import xbmc, xbmcaddon, py2_encode
@@ -69,6 +70,8 @@ def generate_payload(provider, generator, filtering, verify_name=True, verify_si
             log.debug(filtering.reason)
 
     log.debug('[%s] >>>>>> %s would send %d torrents to Elementum <<<<<<<' % (provider, provider, len(results)))
+    results = cleanup_results(results)
+    log.debug('[%s] >>>>>> %s would send %d torrents to Elementum after cleanup <<<<<<<' % (provider, provider, len(results)))
 
     return results
 


### PR DESCRIPTION
There are cases when provider _can_ find some results, but they are later filtered because of different reasons, in my case they had no seeds:
```
2021-08-03 23:31:57.921 T:28768   DEBUG <general>: [script.elementum.burst] [rarbg] >>>>>> rarbg would send 4 torrents to Elementum <<<<<<<
2021-08-03 23:31:57.921 T:28768   DEBUG <general>: [script.elementum.burst] [RARBG] Skipping due to no seeds: 'Its.Always.Sunny.in.Philadelphia.S10E01.WEBRip.x264-ION10'
2021-08-03 23:31:57.921 T:28768   DEBUG <general>: [script.elementum.burst] [RARBG] Skipping due to no seeds: 'Its.Always.Sunny.in.Philadelphia.S10E01.1080p.WEB.x264-CONVOY[rartv]'
2021-08-03 23:31:57.921 T:28768   DEBUG <general>: [script.elementum.burst] [RARBG] Skipping due to no seeds: 'Its.Always.Sunny.in.Philadelphia.S10E01.720p.HDTV.x264-KILLERS[rartv]'
2021-08-03 23:31:57.921 T:28768   DEBUG <general>: [script.elementum.burst] [RARBG] Skipping due to no seeds: 'Its.Always.Sunny.in.Philadelphia.S10E01.HDTV.x264-KILLERS[rartv]'
```
Even though no meaningful results returned, _burst_ won't try fallback queries as it has 4 results in its list. To fix it we apply result filtering before adding results to the list.
So now these 4 torrents will be filtered out and _burst_ next will try fallback queries:
```
...
2021-08-03 23:31:57.922 T:28768   DEBUG <general>: [script.elementum.burst] [rarbg] Before keywords - Query: '{title:en} s{season:2}' - Extra: ''
2021-08-03 23:31:57.922 T:28768 WARNING <general>: [script.elementum.burst] [rarbg] Using translated 'en' title 'its always sunny in philadelphia'
2021-08-03 23:31:57.922 T:28768   DEBUG <general>: [script.elementum.burst] [rarbg] After keywords  - Query: 'its%20always%20sunny%20in%20philadelphia%20s10' - Extra: ''
...
2021-08-03 23:31:58.453 T:28768   DEBUG <general>: [script.elementum.burst] [rarbg] >>>>>> rarbg would send 25 torrents to Elementum <<<<<<<
```
And in these 25 new torrents good ones will be found.