### PR TITLE
Fix results sorting when allow_noseeds, fix sorting by size

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -29,7 +29,7 @@ from .provider import process
 from .providers.definitions import definitions, longest
 from .filtering import apply_filters, Filtering, cleanup_results
 from .client import USER_AGENT, Client
-from .utils import ADDON_ICON, notify, translation, sizeof, get_icon_path, get_enabled_providers, get_alias
+from .utils import ADDON_ICON, notify, translation, sizeof, get_icon_path, get_enabled_providers, get_alias, size_int
 
 provider_names = []
 provider_results = []
@@ -218,13 +218,13 @@ def got_results(provider, results):
 
     if not sort_by or sort_by == 3 or sort_by > 3:
         # TODO: think of something interesting to balance sort results
-        sorted_results = sorted(results, key=lambda r: (nonesorter(r['sort_balance'])), reverse=True)
+        sorted_results = sorted(results, key=lambda r: (r['sort_balance']), reverse=True)
     elif sort_by == 0:
-        sorted_results = sorted(results, key=lambda r: (nonesorter(r['sort_resolution'])), reverse=True)
+        sorted_results = sorted(results, key=lambda r: (r['sort_resolution']), reverse=True)
     elif sort_by == 1:
-        sorted_results = sorted(results, key=lambda r: (nonesorter(r['seeds'])), reverse=True)
+        sorted_results = sorted(results, key=lambda r: (r['seeds']), reverse=True)
     elif sort_by == 2:
-        sorted_results = sorted(results, key=lambda r: (nonesorter(r['size'])), reverse=True)
+        sorted_results = sorted(results, key=lambda r: (size_int(r['size'])), reverse=True)
 
     if len(sorted_results) > max_results:
         sorted_results = sorted_results[:max_results]
@@ -656,7 +656,3 @@ def get_search_query(definition, key):
         return "dom." + definition['parser'][key]
     return definition['parser'][key]
 
-def nonesorter(a):
-    if not a:
-        return ""
-    return a

--- a/burst/utils.py
+++ b/burst/utils.py
@@ -290,6 +290,8 @@ def clean_size(string):
         pos = string.rfind('B')
         if pos > 0:
             string = string[:pos] + 'B'
+    else:
+        string = ""
     return string
 
 


### PR DESCRIPTION
Fix results sorting when allow_noseeds is enabled. Also fix sorting by size.

---

Как я понимаю [`nonesorter` был создан](https://github.com/elgatito/script.elementum.burst/commit/015d61aee9784566019e754383a135aad6e4a989) только для `size`, так как остальные поля у нас всегда становятся int:
`size`:
https://github.com/elgatito/script.elementum.burst/blob/ab939cda886fa95f6c7a39476e9e61fdaffda1c1/burst/provider.py#L45
https://github.com/elgatito/script.elementum.burst/blob/ab939cda886fa95f6c7a39476e9e61fdaffda1c1/burst/utils.py#L280
`seeds`:
https://github.com/elgatito/script.elementum.burst/blob/ab939cda886fa95f6c7a39476e9e61fdaffda1c1/burst/utils.py#L174
`sort_resolution`:
https://github.com/elgatito/script.elementum.burst/blob/ab939cda886fa95f6c7a39476e9e61fdaffda1c1/burst/filtering.py#L641
`sort_balance`:
https://github.com/elgatito/script.elementum.burst/blob/ab939cda886fa95f6c7a39476e9e61fdaffda1c1/burst/provider.py#L52

Но отдача `""` в `nonesorter` ломает сортировку int когда `allow_noseeds` включен - из `0` делает `""`.

В общем, я просто сделал чтобы `size` становился строкой, если он пришёл как `None`.

Плюс, исправил сортировку по размеру, раньше сортировалось по строкам, соотв `700 MB` было больше чем `10 GB`.

Fixes https://github.com/elgatito/plugin.video.elementum/issues/948