### PR TITLE
Fix 'generator' object has no attribute 'next'.

### DIFF
--- a/burst/parser/ehp.py
+++ b/burst/parser/ehp.py
@@ -417,7 +417,7 @@ class Root(list):
         seq = self.match(*args)
 
         try:
-            item = seq.next()
+            item = next(seq)
         except StopIteration:
             return None
         else:
@@ -431,7 +431,7 @@ class Root(list):
         seq = self.match_with_root(*args)
 
         try:
-            item = seq.next()
+            item = next(seq)
         except StopIteration:
             return None
         else:
@@ -599,7 +599,7 @@ class Root(list):
         seq = self.find(name, 1, 1, *args)
 
         try:
-            item = seq.next()
+            item = next(seq)
         except StopIteration:
             return None
         else:
@@ -637,7 +637,7 @@ class Root(list):
         seq = self.find_with_root(name, *args)
 
         try:
-            item = seq.next()
+            item = next(seq)
         except StopIteration:
             return None
         else:


### PR DESCRIPTION
in log file:
`critical <general>: [script.elementum.burst] [zamunda] Got an exception while parsing results: AttributeError("'generator' object has no attribute 'next'")`

the fix: https://www.delftstack.com/howto/python/attributeerror-generator-object-has-no-attribute-next/

works with python 2 and 3 - i double checked.

fixes #372.
