### PR TITLE
Improve nyaa anime_keywords

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -67,7 +67,7 @@ def search(payload, method="general"):
 
     Args:
         payload (dict): Search payload from Elementum.
-        method   (str): Type of search, can be ``general``, ``movie``, ``show``, ``season`` or ``anime``
+        method   (str): Type of search, can be ``general``, ``movie``, ``show``, ``season`` or ``episode``
 
     Returns:
         list: All filtered results in the format Elementum expects

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1734,9 +1734,9 @@
         "tv_keywords_fallback2": "{title:original} \"Сезон {season}\""
     },
     "nyaa": {
-        "anime_keywords": "{title:original} s{season:2}e{episode:2}",
-        "anime_keywords2": "{title} {season:2}x01|S{season:2}",
-        "anime_keywords_fallback": "{title} s{season:2}",
+        "anime_keywords": "{title:original:jp} s{season:2}e{episode:2}",
+        "anime_keywords2": "{title:original:jp} {absolute_episode:2}",
+        "anime_keywords_fallback": "{title:original:jp} s{season:2}",
         "anime_query": "",
         "base_url": "https://nyaa.si/?f=0&c=1_0&q=QUERYEXTRA&s=seeders&o=desc",
         "color": "FF88D201",
@@ -1776,8 +1776,8 @@
         "tv_extra": "",
         "tv_extra2": "",
         "tv_keywords": "{title:original} s{season:2}e{episode:2}",
-        "tv_keywords2": "{title} {season:2}x01|S{season:2}",
-        "tv_keywords_fallback": "{title} s{season:2}"
+        "tv_keywords2": "{title:original} {absolute_episode:2}",
+        "tv_keywords_fallback": "{title:original} s{season:2}"
     },
     "rarbg": {
         "anime_keywords": "{title:en:original} s{season:2}e{episode:2}",

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1750,7 +1750,7 @@
         "login_object": "",
         "login_path": null,
         "movie_extra": "",
-        "movie_keywords": "{title:original} {year}",
+        "movie_keywords": "{title:original:jp} {year}",
         "movie_query": "",
         "name": "Nyaa",
         "parser": {
@@ -1767,17 +1767,17 @@
         "root_url": "https://www.nyaa.si/",
         "season_extra": "",
         "season_extra2": "",
-        "season_keywords": "{title:original} season {season:2}",
-        "season_keywords2": "{title:original} s{season:2}",
+        "season_keywords": "{title:original:jp} season {season:2}",
+        "season_keywords2": "{title:original:jp} s{season:2}",
         "season_query": "",
         "separator": "+",
         "show_query": "",
         "subpage": null,
         "tv_extra": "",
         "tv_extra2": "",
-        "tv_keywords": "{title:original} s{season:2}e{episode:2}",
-        "tv_keywords2": "{title:original} {absolute_episode:2}",
-        "tv_keywords_fallback": "{title:original} s{season:2}"
+        "tv_keywords": "{title:original:jp} s{season:2}e{episode:2}",
+        "tv_keywords2": "{title:original:jp} {absolute_episode:2}",
+        "tv_keywords_fallback": "{title:original:jp} s{season:2}"
     },
     "rarbg": {
         "anime_keywords": "{title:en:original} s{season:2}e{episode:2}",


### PR DESCRIPTION
use absolute_episode, use "jp" lang (romanization of Japanese), do not use "|" - unsupported, do not use {season:2}x01 - they do not use it.

this significantly increases number of results without adding wrong results.

example:
```
[script.elementum.burst] -   nyaa query: 'delicious%20in%20dungeon%2006'
[script.elementum.burst] -   nyaa query: 'dungeon%20meshi%2006'
```