### PR TITLE
Fix get_setting choices usage in get_enabled_providers

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -67,7 +67,7 @@ def search(payload, method="general"):
 
     Args:
         payload (dict): Search payload from Elementum.
-        method   (str): Type of search, can be ``general``, ``movie``, ``show``, ``season`` or ``episode``
+        method   (str): Type of search, can be ``general``, ``movie``, ``season`` or ``episode``
 
     Returns:
         list: All filtered results in the format Elementum expects

--- a/burst/utils.py
+++ b/burst/utils.py
@@ -134,20 +134,20 @@ def get_enabled_providers(method):
         list: All available enabled provider IDs
     """
     results = []
-    type = "2"
-    if method == "general":
-        type = "0"
-    elif method == "movie":
-        type = "1"
+    content_type = 'Shows' # if method == 'season' or method == 'episode' or method == 'anime'
+    if method == 'general':
+        content_type = 'All'
+    elif method == 'movie':
+        content_type = 'Movies'
     for provider in definitions:
         if 'enabled' in definitions[provider] and not definitions[provider]['enabled']:
             continue
 
         if get_setting('use_%s' % provider, bool):
             contains = get_setting('%s_contains' % provider, choices=('All', 'Movies', 'Shows'))
-            if not contains or contains == "0":
+            if not contains or contains == 'All': # treat absence of setting as All
                 results.append(provider)
-            elif contains == type:
+            elif contains == content_type:
                 results.append(provider)
         if 'custom' in definitions[provider] and definitions[provider]['custom']:
             results.append(provider)


### PR DESCRIPTION
Fix get_setting choices usage in get_enabled_providers.
so now we actually use choices and not strings value of integers (like `"0"`).
depends on https://github.com/elgatito/plugin.video.elementum/pull/994