### PR TITLE
Add overwrite_anime_original_title option

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -38,6 +38,7 @@ use_min_size = get_setting('min_size')
 use_max_size = get_setting('max_size')
 use_filter_quotes = get_setting("filter_quotes", bool)
 use_allow_noseeds = get_setting('allow_noseeds', bool)
+overwrite_anime_original_title = get_setting('overwrite_anime_original_title', choices=('original', 'jp', 'en'))
 
 class Filtering:
     """
@@ -263,7 +264,7 @@ class Filtering:
 
         self.collect_queries('tv', definition)
 
-    def use_season(self, provider, info):
+    def use_season(self, provider, payload):
         """ Setup method to define season search parameters
 
         Args:
@@ -283,12 +284,12 @@ class Filtering:
             self.min_size = get_float(get_setting('min_size_seasons'))
             self.max_size = get_float(get_setting('max_size_seasons'))
             self.check_sizes()
-        self.info = info
+        self.info = payload
         self.url = u"%s%s" % (definition['base_url'], season_query)
 
         self.collect_queries('season', definition)
 
-    def use_anime(self, provider, info):
+    def use_anime(self, provider, payload):
         """ Setup method to define anime search parameters
 
         Args:
@@ -308,7 +309,14 @@ class Filtering:
             self.min_size = get_float(get_setting('min_size_episodes'))
             self.max_size = get_float(get_setting('max_size_episodes'))
             self.check_sizes()
-        self.info = info
+        self.info = payload
+        if 'titles' in self.info and self.info['titles']:
+            if overwrite_anime_original_title == 'jp':
+                if 'jp' in self.info['titles'] and self.info['titles']['jp']:
+                    self.info['titles']['original'] = self.info['titles']['jp']
+            elif overwrite_anime_original_title == 'en':
+                if 'en' in self.info['titles'] and self.info['titles']['en']:
+                    self.info['titles']['original'] = self.info['titles']['en']
         self.url = u"%s%s" % (definition['base_url'], anime_query)
 
         self.collect_queries('anime', definition)

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -463,8 +463,8 @@ class Filtering:
         for keyword in keywords:
             keyword = keyword.lower()
             if 'title' in keyword:
-                title = self.info["title"]
-                language = definitions[provider]['language']
+                title = self.info['title']
+                provider_language = definitions[provider]['language']
                 use_language = None
                 if ':' in keyword:
                     use_language = keyword.split(':')[1].lower()
@@ -474,8 +474,8 @@ class Filtering:
                     try:
                         if not use_language and self.kodi_language and self.kodi_language in self.info['titles']:
                             use_language = self.kodi_language
-                        if not use_language and language and language in self.info['titles']:
-                            use_language = language
+                        if not use_language and provider_language and provider_language in self.info['titles']:
+                            use_language = provider_language
                         if use_language not in self.info['titles'] or not self.info['titles'][use_language]:
                             log.info("[%s] Falling back to original title in absence of %s language title" % (provider, use_language))
                             use_language = "original"

--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -392,3 +392,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Lithuania/strings.po
+++ b/resources/language/Lithuania/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -393,3 +393,15 @@ msgstr "Обслуживание"
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr "Удалить файлы cookie"
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr "Установить 'оригинальное' название Аниме как:"
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr "Японский латиницей (Ромадзи)"
+
+msgctxt "#32148"
+msgid "Original"
+msgstr "Исходное"

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -393,3 +393,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -393,3 +393,15 @@ msgstr "Обслуговування"
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr "Видалити файли cookie"
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -394,3 +394,15 @@ msgstr ""
 msgctxt "#32145"
 msgid "Remove cookies"
 msgstr ""
+
+msgctxt "#32146"
+msgid "Set 'original' title of Anime to:"
+msgstr ""
+
+msgctxt "#32147"
+msgid "Romanization of Japanese"
+msgstr ""
+
+msgctxt "#32148"
+msgid "Original"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -24,9 +24,6 @@
     <setting label="32124" id="auto_timeout" type="bool" default="true" />
     <setting label="32070" id="timeout" type="slider" default="25" option="int" range="3,1,180" enable="eq(-1,false)" />
     <setting label="32071" id="timeout_help" type="text" enable="false" subsetting="true" />
-
-    <setting type="sep"/>
-    <setting label="32132" id="filter_quotes" type="bool" default="false" />
   </category>
 
   <!-- Providers -->
@@ -387,11 +384,15 @@
     <setting label="32009" type="lsep" subsetting="true" enable="eq(-7,true)" />
     <setting label="32033" id="min_size_episodes" type="slider" option="float" range="0,0.25,100" default="0" subsetting="true" enable="eq(-8,true)" />
     <setting label="32034" id="max_size_episodes" type="slider" option="float" range="1,0.25,200" default="100" subsetting="true" enable="eq(-9,true)" />
+    <setting type="lsep" />
     <setting label="32036" id="additional_filters" type="bool" default="false" />
     <setting label="32037" id="filtering_help" type="text" enable="false" subsetting="true" />
     <setting label="32038" id="accept" type="text" default="" subsetting="true" enable="eq(-2,true)" />
     <setting label="32039" id="block" type="text" default="" subsetting="true" enable="eq(-3,true)" />
     <setting label="32017" id="require" type="text" default="" subsetting="true" enable="eq(-4,true)" />
+    <setting type="sep"/>
+    <setting label="32132" id="filter_quotes" type="bool" default="false" />
+    <setting label="32146" id="overwrite_anime_original_title" type="enum" default="1" subsetting="true" lvalues="32148|32147|32111" />
     <setting label="32018" id="kodi_language" type="bool" default="false" />
     <setting label="32050" id="language_exceptions" type="text" subsetting="true" enable="eq(-1,true)" />
     <setting label="32051" id="language_help" type="text" enable="false" subsetting="true" />


### PR DESCRIPTION
Option to set 'original' title of Anime to: Original/"Romanization of Japanese"/English.

fixes https://github.com/elgatito/script.elementum.burst/issues/387
fixes https://github.com/elgatito/plugin.video.elementum/issues/987

depends on https://github.com/elgatito/plugin.video.elementum/pull/994