### PR TITLE
Enable kodi_language by default.

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -393,7 +393,7 @@
     <setting type="sep"/>
     <setting label="32132" id="filter_quotes" type="bool" default="false" />
     <setting label="32146" id="overwrite_anime_original_title" type="enum" default="1" subsetting="true" lvalues="32148|32147|32111" />
-    <setting label="32018" id="kodi_language" type="bool" default="false" />
+    <setting label="32018" id="kodi_language" type="bool" default="true" />
     <setting label="32050" id="language_exceptions" type="text" subsetting="true" enable="eq(-1,true)" />
     <setting label="32051" id="language_help" type="text" enable="false" subsetting="true" />
 


### PR DESCRIPTION
to keep backward compatibility with old way - so nothing will change for users.

also, it anyway makes sense to use translated title by default, since many people want to get "local" releases.
also, many providers that do not support translated queries already have `:en` or `:original` set in queries.

for https://github.com/elgatito/plugin.video.elementum/issues/991