### PR TITLE
Use included_rx func for require_keywords, same as for other checks.

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -71,15 +71,6 @@ class Filtering:
     """
     def __init__(self):
         resolutions = OrderedDict()
-
-        # TODO: remove when finished with debugging resolutions detection
-        # resolutions['filter_240p'] = ['240p', '240р', '_tvrip_', 'satrip', 'vhsrip']
-        # resolutions['filter_480p'] = ['480p', '480р', 'xvid', 'dvd', 'dvdrip', 'hdtv']
-        # resolutions['filter_720p'] = ['720p', '720р', 'hdrip', 'bluray', 'blu_ray', 'brrip', 'bdrip', 'hdtv', '/hd720p', '1280x720']
-        # resolutions['filter_1080p'] = ['1080p', '1080р', '1080i', 'fullhd', '_fhd_', '/hd1080p', '/hdr1080p', '1920x1080']
-        # resolutions['filter_2k'] = ['_2k_', '1440p', '1440р', '_2к_']
-        # resolutions['filter_4k'] = ['_4k_', '2160p', '2160р', '_uhd_', '_4к_']
-
         resolutions['filter_240p'] = ['240[pр]', 'vhs\-?rip']
         resolutions['filter_480p'] = ['480[pр]', 'xvid|dvd|dvdrip|hdtv|web\-(dl)?rip|iptv|sat\-?rip|tv\-?rip']
         resolutions['filter_720p'] = ['720[pр]|1280x720', 'hd720p?|hd\-?rip|b[rd]rip']
@@ -87,7 +78,6 @@ class Filtering:
         resolutions['filter_2k'] = ['1440[pр]', '2k']
         resolutions['filter_4k'] = ['4k|2160[pр]|uhd', '4k|hd4k']
         resolutions['filter_music'] = ['mp3|flac|alac|ost|sound\-?track']
-
         self.resolutions = resolutions
 
         self.release_types = {
@@ -102,30 +92,12 @@ class Filtering:
             'filter_telesync': ['telesync|ts|tc'],
             'filter_cam': ['cam|hd\-?cam'],
             'filter_tvrip': ['tv\-?rip|sat\-?rip|dvb'],
-            'filter_vhsrip': ['vhs\-?rip'],
             'filter_iptvrip': ['iptv\-?rip'],
+            'filter_vhsrip': ['vhs\-?rip'],
             'filter_trailer': ['trailer|трейлер|тизер'],
             'filter_workprint': ['workprint'],
             'filter_line': ['line']
         }
-
-        # TODO: remove when finished with debugging resolutions detection
-        # self.release_types = {
-        #     'filter_brrip': ['brrip', 'bdrip', 'bd-rip', 'bluray', 'blu-ray', 'bdremux', 'bd-remux'],
-        #     'filter_webdl': ['webdl', 'webrip', 'web-rip', 'web_dl', 'dlrip', '_yts_'],
-        #     'filter_hdrip': ['hdrip', 'hd-rip'],
-        #     'filter_hdtv': ['hdtv'],
-        #     'filter_dvd': ['_dvd_', 'dvdrip', 'dvd-rip', 'vcdrip'],
-        #     'filter_dvdscr': ['dvdscr', 'dvd-scr'],
-        #     'filter_screener': ['screener', '_scr_'],
-        #     'filter_3d': ['_3d_'],
-        #     'filter_telesync': ['telesync', '_ts_', '_tc_'],
-        #     'filter_cam': ['_cam_', 'hdcam'],
-        #     'filter_tvrip': ['_tvrip', 'satrip'],
-        #     'filter_vhsrip': ['vhsrip'],
-        #     'filter_trailer': ['trailer', 'трейлер', 'тизер'],
-        #     'filter_workprint': ['workprint']
-        # }
 
         require = []
         resolutions_allow = []
@@ -611,7 +583,7 @@ class Filtering:
 
         if self.require_keywords and use_require_keywords:
             for required in self.require_keywords:
-                if not self.included(name, keys=[required]):
+                if not self.included_rx(name, keys=[required]):
                     self.reason += " Missing required keyword"
                     return False
 
@@ -685,7 +657,7 @@ class Filtering:
             for key in keys:
                 res2 = []
                 for item in re.split(r'\s', key):
-                    item = item.replace('_', ' ')
+                    item = item.replace('_', ' ') # for keyword like _HEVC_
                     if strict:
                         item = ' ' + item + ' '
                     if item.lower() in value:
@@ -704,7 +676,7 @@ class Filtering:
             keys   (list): List of regex that must be found in ``value``
 
         Returns:
-            bool: True if any (or all if ``strict``) keys are included, False otherwise.
+            bool: True if any of keys is included, False otherwise.
         """
         value = ' ' + value.lower() + ' '
         for key in keys:

--- a/resources/language/Croatian/strings.po
+++ b/resources/language/Croatian/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Dodatni filtri ključne riječi (zarezom odvojeno)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Koristite podvlake oko ključnih riječi za zahtijev razmaka/ točke, npr. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Prihvati"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/French/strings.po
+++ b/resources/language/French/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Filtres de mots clés supplémentaires (séparés par des virgules)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Utilisez des traits de soulignement par exemple. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Accepter"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Hebrew/strings.po
+++ b/resources/language/Hebrew/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "מילות מפתח נוספות לסינון (מופרדות בפסיק)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "שימוש בקו תחתון במקום רווח/נקודה. לדוגמה _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "לקבל"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -69,10 +69,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "További kulcsszó szűrők (vesszővel elválasztva)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Használjon aláhúzásokat a kulcsszavak körül, hogy helyettesítsen egy space/pont karaktert (pl. _HEVC_)"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Elfogad"
@@ -403,4 +399,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Italian/strings.po
+++ b/resources/language/Italian/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Filtri parole chiave aggiuntivi (separati da virgola)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Usa i trattini bassi intorno alle parole chiave per richiedere uno spazio/punto, ad es. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Accettare"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Lithuania/strings.po
+++ b/resources/language/Lithuania/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Papildomi raktinių žodžių filtrai (atskirti kableliais)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Naudokite raktinių žodžių raides, kad būtų reikalingas tarpas / taškas, pvz. _HEVC"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Patvirtinti"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Portuguese (Brazil)/strings.po
+++ b/resources/language/Portuguese (Brazil)/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Portuguese/strings.po
+++ b/resources/language/Portuguese/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Дополнительные слова-фильтры (через запятую)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Использовать подчеркивание для требования наличия пробела/точки возле слова"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Принять"
@@ -92,7 +88,7 @@ msgstr "Исключения"
 
 msgctxt "#32051"
 msgid "Comma-separated list of providers to exclude, eg. yts, rarbg"
-msgstr "Список провайдеров для исключения, через запятую, напр. yts, rarbg"
+msgstr "Список провайдеров для исключ. через запятую, напр. yts, rarbg"
 
 msgctxt "#32060"
 msgid "No providers enabled"
@@ -376,7 +372,7 @@ msgstr "Использовать домены в Tor"
 
 msgctxt "#32141"
 msgid "First set SOCKS both in Burst&Elementum or proxy http via Elementum"
-msgstr "Сперва вкл. SOCKS5h в Burst&Elementum или вкл. прокси через Elementum"
+msgstr "Сперва вкл. SOCKS5h в Burst&Elementum или [CR]вкл. прокси через Elementum"
 
 msgctxt "#32142"
 msgid "Arabic"
@@ -405,3 +401,11 @@ msgstr "Японский латиницей (Ромадзи)"
 msgctxt "#32148"
 msgid "Original"
 msgstr "Исходное"
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr "Принять/Забл.: любое из слов должно быть в названии торрента,[CR]чтобы его принять/забл. Обязательно: все слова должны быть."
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
+msgstr "Пример: 'HDR, .?265, Hindi'. Можно регулярные выражения.[CR]Вы можете фильтровать языки, видео/аудио фишки и т.д."

--- a/resources/language/Spanish (Argentina)/strings.po
+++ b/resources/language/Spanish (Argentina)/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Filtros de palabras adicionales (separados por coma)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Use _ alrededor de palabras p/especificar un espacio/punto, ej. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Aceptar"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Spanish (Mexico)/strings.po
+++ b/resources/language/Spanish (Mexico)/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Palabras claves, filtrado adicional (separado por comas)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Usar guion bajo en las palabras claves para referir un espacio/punto, Por ejemplo _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Aceptar"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Swedish/strings.po
+++ b/resources/language/Swedish/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Ytterligare sökordsfilter (kommaseparerade)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Använd understrykningar runt nyckelord för att kräva ett blanksteg/punkt, t.ex. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Acceptera"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/Ukrainian/strings.po
+++ b/resources/language/Ukrainian/strings.po
@@ -70,10 +70,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr "Додаткові слова-фільтри (через кому)"
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr "Викор. підкреслення навколо слова, щоб форсувати пробіл/крапку, напр. _HEVC_"
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr "Приймати"
@@ -404,4 +400,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/language/messages.pot
+++ b/resources/language/messages.pot
@@ -71,10 +71,6 @@ msgctxt "#32036"
 msgid "Additional keyword filters (comma-separated)"
 msgstr ""
 
-msgctxt "#32037"
-msgid "Use underscores around keywords to require a space/dot, eg. _HEVC_"
-msgstr ""
-
 msgctxt "#32038"
 msgid "Accept"
 msgstr ""
@@ -405,4 +401,12 @@ msgstr ""
 
 msgctxt "#32148"
 msgid "Original"
+msgstr ""
+
+msgctxt "#32149"
+msgid "Accept/Block: any of keywords should be in torrent name to [CR]accept/block torrent. Require: all keywords must be in name."
+msgstr ""
+
+msgctxt "#32150"
+msgid "Example: 'HDR, .?265, Hindi'. Regexp are supported.[CR]You can filter languages, video/audio features, etc."
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -384,15 +384,16 @@
     <setting label="32009" type="lsep" subsetting="true" enable="eq(-7,true)" />
     <setting label="32033" id="min_size_episodes" type="slider" option="float" range="0,0.25,100" default="0" subsetting="true" enable="eq(-8,true)" />
     <setting label="32034" id="max_size_episodes" type="slider" option="float" range="1,0.25,200" default="100" subsetting="true" enable="eq(-9,true)" />
-    <setting type="lsep" />
+    <setting type="sep" />
     <setting label="32036" id="additional_filters" type="bool" default="false" />
-    <setting label="32037" id="filtering_help" type="text" enable="false" subsetting="true" />
+    <setting label="32149" id="filtering_help1" type="text" enable="false" subsetting="true" />
     <setting label="32038" id="accept" type="text" default="" subsetting="true" enable="eq(-2,true)" />
     <setting label="32039" id="block" type="text" default="" subsetting="true" enable="eq(-3,true)" />
     <setting label="32017" id="require" type="text" default="" subsetting="true" enable="eq(-4,true)" />
+    <setting label="32150" id="filtering_help2" type="text" enable="false" subsetting="true" />
     <setting type="sep"/>
     <setting label="32132" id="filter_quotes" type="bool" default="false" />
-    <setting label="32146" id="overwrite_anime_original_title" type="enum" default="1" subsetting="true" lvalues="32148|32147|32111" />
+    <setting label="32146" id="overwrite_anime_original_title" type="enum" default="1" lvalues="32148|32147|32111" />
     <setting label="32018" id="kodi_language" type="bool" default="true" />
     <setting label="32050" id="language_exceptions" type="text" subsetting="true" enable="eq(-1,true)" />
     <setting label="32051" id="language_help" type="text" enable="false" subsetting="true" />


### PR DESCRIPTION
Use included_rx() func for require_keywords, same as for other checks.

So now check logic for "Require" is same as "Accept"/"Block". Also user can use regexp.
I also added detailed help messages.
I had to split help into 2 messages since skin allow maximum 60 characters and 2 lines maximum. And if such lines are close - then then text is overlapping. Thus 1st line on top and 2nd on bottom.

also i removed old patterns that uses `_word_` - this is only supported by old included() func, but this func is a legacy and works strange.
I moved filter_vhsrip in code so now it has the same position as it has in settings.


fixes https://github.com/elgatito/script.elementum.burst/issues/393

![Screenshot_20240319_163631](https://github.com/elgatito/script.elementum.burst/assets/17964763/a602abf2-4389-4d61-b7cb-23a7f0f39b62)
