### PR TITLE
proxy_enabled should not be disabled by use_elementum_proxy

### DIFF
--- a/burst/client.py
+++ b/burst/client.py
@@ -189,7 +189,7 @@ class Client:
                     'http': self.proxy_url,
                     'https': self.proxy_url,
                 }
-        elif proxy['enabled']:
+        if proxy['enabled']:
             if proxy['use_type'] == 0 and info and "proxy_url" in info:
                 log.debug("Setting proxy from Elementum: %s" % (info["proxy_url"]))
 


### PR DESCRIPTION
Right now if use_elementum_proxy is enabled (and it is enabled by default) then `proxy_enabled` is automatically ignored which is very confusing behavior imho.

Either we should change `elif` to `if` or we should add help that says: "in order to use proxy, you need to disable use_elementum_proxy first".
elif->if just looks as more simple solution but i can also create a help message.