### PR TITLE
fix requests/compat.py to work on python 2.7

### DIFF
--- a/resources/site-packages/requests/compat.py
+++ b/resources/site-packages/requests/compat.py
@@ -44,8 +44,7 @@ if is_py2:
     from Cookie import Morsel
     from StringIO import StringIO
     from collections import Callable, Mapping, MutableMapping
-
-    from urllib3.packages.ordered_dict import OrderedDict
+    from collections import OrderedDict
 
     builtin_str = str
     bytes = str


### PR DESCRIPTION
after https://github.com/elgatito/script.elementum.burst/pull/416


не стал возвращать ordered_dict.py который для 2,6 так как urllib3 всё равно не работает с 2,6