### PR TITLE
Use raw strings for regexp

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -413,7 +413,7 @@ def extract_torrents(provider, client):
                 else:
                     parsed_url = urlparse(torrent.split('|')[0])
                     cookie_domain = '{uri.netloc}'.format(uri=parsed_url)
-                    cookie_domain = re.sub('www\d*\.', '', cookie_domain)
+                    cookie_domain = re.sub(r'www\d*\.', '', cookie_domain)
                     cookies = {}
 
                     # Collect cookies used in request
@@ -606,50 +606,50 @@ def extract_from_page(provider, content):
             log.debug('[%s] Matched magnet link: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('http(.*?).torrent["\']', content)
+        matches = re.findall(r'http(.*?).torrent["\']', content)
         if matches:
             result = 'http' + matches[0] + '.torrent'
             result = result.replace('torcache.net', 'itorrents.org')
             log.debug('[%s] Matched torrent link: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('/download\?token=[A-Za-z0-9%]+', content)
+        matches = re.findall(r'/download\?token=[A-Za-z0-9%]+', content)
         if matches:
             result = definition['root_url'] + matches[0]
             log.debug('[%s] Matched download link with token: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('"(/download/[A-Za-z0-9]+)"', content)
+        matches = re.findall(r'"(/download/[A-Za-z0-9]+)"', content)
         if matches:
             result = definition['root_url'] + matches[0]
             log.debug('[%s] Matched download link: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('/torrents/download/\?id=[a-z0-9-_.]+', content)  # t411
+        matches = re.findall(r'/torrents/download/\?id=[a-z0-9-_.]+', content)  # t411
         if matches:
             result = definition['root_url'] + matches[0]
             log.debug('[%s] Matched download link with an ID: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('\: ([A-Fa-f0-9]{40})', content)
+        matches = re.findall(r'\: ([A-Fa-f0-9]{40})', content)
         if matches:
             result = "magnet:?xt=urn:btih:" + matches[0]
             log.debug('[%s] Matched magnet info_hash search: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('/download.php\?id=([A-Za-z0-9]{40})\W', content)
+        matches = re.findall(r'/download.php\?id=([A-Za-z0-9]{40})\W', content)
         if matches:
             result = "magnet:?xt=urn:btih:" + matches[0]
             log.debug('[%s] Matched download link: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('(/download.php\?id=[A-Za-z0-9]+[^\s\'"]*)', content)
+        matches = re.findall(r'(/download.php\?id=[A-Za-z0-9]+[^\s\'"]*)', content)
         if matches:
             result = definition['root_url'] + matches[0]
             log.debug('[%s] Matched download link: %s' % (provider, repr(result)))
             return result
 
-        matches = re.findall('/get_torrent/([A-Fa-f0-9]{40})', content)
+        matches = re.findall(r'/get_torrent/([A-Fa-f0-9]{40})', content)
         if matches:
             result = "magnet:?xt=urn:btih:" + matches[0]
             log.debug('[%s] Matched magnet info_hash search: %s' % (provider, repr(result)))

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -71,29 +71,29 @@ class Filtering:
     """
     def __init__(self):
         resolutions = OrderedDict()
-        resolutions['filter_240p'] = ['240[pр]', 'vhs\-?rip']
-        resolutions['filter_480p'] = ['480[pр]', 'xvid|dvd|dvdrip|hdtv|web\-(dl)?rip|iptv|sat\-?rip|tv\-?rip']
-        resolutions['filter_720p'] = ['720[pр]|1280x720', 'hd720p?|hd\-?rip|b[rd]rip']
-        resolutions['filter_1080p'] = ['1080[piр]|1920x1080', 'hd1080p?|fullhd|fhd|blu\W*ray|bd\W*remux']
+        resolutions['filter_240p'] = ['240[pр]', r'vhs\-?rip']
+        resolutions['filter_480p'] = ['480[pр]', r'xvid|dvd|dvdrip|hdtv|web\-(dl)?rip|iptv|sat\-?rip|tv\-?rip']
+        resolutions['filter_720p'] = ['720[pр]|1280x720', r'hd720p?|hd\-?rip|b[rd]rip']
+        resolutions['filter_1080p'] = ['1080[piр]|1920x1080', r'hd1080p?|fullhd|fhd|blu\W*ray|bd\W*remux']
         resolutions['filter_2k'] = ['1440[pр]', '2k']
         resolutions['filter_4k'] = ['4k|2160[pр]|uhd', '4k|hd4k']
-        resolutions['filter_music'] = ['mp3|flac|alac|ost|sound\-?track']
+        resolutions['filter_music'] = [r'mp3|flac|alac|ost|sound\-?track']
         self.resolutions = resolutions
 
         self.release_types = {
-            'filter_brrip': ['brrip|bd\-?rip|blu\-?ray|bd\-?remux'],
-            'filter_webdl': ['web_?\-?dl|web\-?rip|dl\-?rip|yts'],
-            'filter_hdrip': ['hd\-?rip'],
-            'filter_hdtv': ['hd\-?tv'],
-            'filter_dvd': ['dvd|dvd\-?rip|vcd\-?rip'],
-            'filter_dvdscr': ['dvd\-?scr'],
+            'filter_brrip': [r'brrip|bd\-?rip|blu\-?ray|bd\-?remux'],
+            'filter_webdl': [r'web_?\-?dl|web\-?rip|dl\-?rip|yts'],
+            'filter_hdrip': [r'hd\-?rip'],
+            'filter_hdtv': [r'hd\-?tv'],
+            'filter_dvd': [r'dvd|dvd\-?rip|vcd\-?rip'],
+            'filter_dvdscr': [r'dvd\-?scr'],
             'filter_screener': ['screener|scr'],
             'filter_3d': ['3d'],
             'filter_telesync': ['telesync|ts|tc'],
-            'filter_cam': ['cam|hd\-?cam'],
-            'filter_tvrip': ['tv\-?rip|sat\-?rip|dvb'],
-            'filter_iptvrip': ['iptv\-?rip'],
-            'filter_vhsrip': ['vhs\-?rip'],
+            'filter_cam': [r'cam|hd\-?cam'],
+            'filter_tvrip': [r'tv\-?rip|sat\-?rip|dvb'],
+            'filter_iptvrip': [r'iptv\-?rip'],
+            'filter_vhsrip': [r'vhs\-?rip'],
             'filter_trailer': ['trailer|трейлер|тизер'],
             'filter_workprint': ['workprint'],
             'filter_line': ['line']

--- a/burst/normalize.py
+++ b/burst/normalize.py
@@ -100,10 +100,10 @@ def safe_name_torrent(string):
     """
     # erase keyword
     string = string.lower()
-    string = re.sub(u'^\[.*?\]', u'', string)  # erase [HorribleSub] for ex.
+    string = re.sub(r'^\[.*?\]', u'', string)  # erase [HorribleSub] for ex.
     # check for anime
-    string = re.sub(u'- ([0-9][0-9][0-9][0-9]) ', u' \g<1>', string + u' ')
-    string = re.sub(u'- ([0-9]+) ', u'- EP\g<1>', string + u' ')
+    string = re.sub(r'- ([0-9][0-9][0-9][0-9]) ', r' \g<1>', string + u' ')
+    string = re.sub(r'- ([0-9]+) ', r'- EP\g<1>', string + u' ')
     if 'season' not in string.lower():
         string = string.lower().replace(u' episode ', u' - EP')
 

--- a/burst/parser/HTMLParser.py
+++ b/burst/parser/HTMLParser.py
@@ -26,9 +26,9 @@ commentclose = re.compile(r'--\s*>')
 # see http://www.w3.org/TR/html5/tokenization.html#tag-open-state
 # and http://www.w3.org/TR/html5/tokenization.html#tag-name-state
 # note: if you change tagfind/attrfind remember to update locatestarttagend too
-tagfind = re.compile('([a-zA-Z][^\t\n\r\f />\x00]*)(?:\s|/(?!>))*')
+tagfind = re.compile(r'([a-zA-Z][^\t\n\r\f />\x00]*)(?:\s|/(?!>))*')
 # this regex is currently unused, but left for backward compatibility
-tagfind_tolerant = re.compile('[a-zA-Z][^\t\n\r\f />\x00]*')
+tagfind_tolerant = re.compile(r'[a-zA-Z][^\t\n\r\f />\x00]*')
 
 attrfind = re.compile(
     r'((?<=[\'"\s/])[^\s/>][^\s/=>]*)(\s*=+\s*'
@@ -51,7 +51,7 @@ locatestarttagend = re.compile(r"""
 endendtag = re.compile('>')
 # the HTML 5 spec, section 8.1.2.2, doesn't allow spaces between
 # </ and the tag name, so maybe this should be fixed
-endtagfind = re.compile('</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
+endtagfind = re.compile(r'</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
 
 
 class HTMLParseError(Exception):

--- a/burst/provider.py
+++ b/burst/provider.py
@@ -270,7 +270,7 @@ def process(provider, generator, filtering, has_special, verify_name=True, verif
 
                 if not logged_in and 'login_cookie' in definition and definition['login_cookie']:
                     cookie_domain = '{uri.netloc}'.format(uri=urlparse(definition['root_url']))
-                    cookie_domain = re.sub('www\d*\.', '', cookie_domain)
+                    cookie_domain = re.sub(r'www\d*\.', '', cookie_domain)
 
                     client._read_cookies()
                     if client.cookie_exists(definition['login_cookie'], urlparse(definition['root_url']).netloc):

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -3042,7 +3042,7 @@
         "name": "Zamunda",
         "parser": {
             "infohash": "",
-            "name": "item(tag='a', order=2) + ' | ' + unquote(re.sub('/download\\.php/\\d+/','',item.take_with_root(('class', 'fa fa-download'))[0].attr['href'].replace('.torrent', '')))",
+            "name": "item(tag='a', order=2) + ' | ' + unquote(re.sub(r'/download\\.php/\\d+/','',item.take_with_root(('class', 'fa fa-download'))[0].attr['href'].replace('.torrent', '')))",
             "peers": "item(tag='td', order=-1)",
             "row": "find_once('table', ('id', 'zbtable')).find_all('tr', start=2)",
             "seeds": "item(tag='td', order=-2)",
@@ -3087,7 +3087,7 @@
         "name": "Zelka",
         "parser": {
             "infohash": "item.take_with_root(('src', '//img.zamunda.se/pic/magnet-icon-12w-12h.gif'))[0].attr['href'].replace('magnet:?xt=urn:btih:', '') if item.take_with_root(('src', '//img.zamunda.se/pic/magnet-icon-12w-12h.gif')) else ''",
-            "name": "item(tag='a', order=2) + ' | ' + unquote(re.sub('download\\.php/\\d+/','',item.take_with_root(('src', '//img.zamunda.se/pic/download.gif'))[0].attr['href'].replace('.torrent', '')))",
+            "name": "item(tag='a', order=2) + ' | ' + unquote(re.sub(r'download\\.php/\\d+/','',item.take_with_root(('src', '//img.zamunda.se/pic/download.gif'))[0].attr['href'].replace('.torrent', '')))",
             "peers": "item(tag='td', order=-1)",
             "row": "find_once('table', ('width', '900')).find_all('tr', start=2)",
             "seeds": "item(tag='td', order=-2)",

--- a/burst/utils.py
+++ b/burst/utils.py
@@ -45,7 +45,7 @@ class Magnet:
     def __init__(self, magnet):
         self.magnet = magnet + '&'
 
-        info_hash = re.search('urn:btih:(\w+)&', self.magnet, re.IGNORECASE)
+        info_hash = re.search(r'urn:btih:(\w+)&', self.magnet, re.IGNORECASE)
         self.info_hash = None
         if info_hash:
             self.info_hash = info_hash.group(1)


### PR DESCRIPTION
it is as a good practice and also Python 3.12 throw warning like `SyntaxWarning: invalid escape sequence '\-'`.