### PR TITLE
Fix release types detection to avoid false blocks

### DIFF
--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -89,7 +89,7 @@ class Filtering:
             'filter_dvdscr': [r'dvd\-?scr'],
             'filter_screener': ['screener|scr'],
             'filter_3d': ['3d'],
-            'filter_telesync': ['telesync|ts|tc'],
+            'filter_telesync': ['telesync|ts|telecine|tc|hdts'],
             'filter_cam': [r'cam|hd\-?cam'],
             'filter_tvrip': [r'tv\-?rip|sat\-?rip|dvb'],
             'filter_iptvrip': [r'iptv\-?rip'],

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -90,7 +90,7 @@ class Filtering:
             'filter_screener': ['screener|scr'],
             'filter_3d': ['3d'],
             'filter_telesync': ['telesync|ts|telecine|tc|hdts'],
-            'filter_cam': [r'cam|hd\-?cam'],
+            'filter_cam': [r'cam|cam\-?rip|hd\-?cam'],
             'filter_tvrip': [r'tv\-?rip|sat\-?rip|dvb'],
             'filter_iptvrip': [r'iptv\-?rip'],
             'filter_vhsrip': [r'vhs\-?rip'],

--- a/burst/filtering.py
+++ b/burst/filtering.py
@@ -684,7 +684,7 @@ class Filtering:
         """
         value = ' ' + value.lower() + ' '
         for key in keys:
-            rr = r'\W+(' + key + r')\W*'
+            rr = r'\W+(' + key + r')\W+'
             if re.search(rr, value):
                 return True
         return False


### PR DESCRIPTION
Currently in `included_rx()` we search for keyword without end boundary, so keyword `TS` (from filter_telesync) will match movie called Tsunami and will block it. e.g. https://www.themoviedb.org/search/movie?query=tsunami
Same for other "small" keywords: cam, tc, scr.

So I updated included_rx to search whole keyword to avoid false matches.
Since we add spaces around title (`value = ' ' + value.lower() + ' '`) we can simply use `\W+` - it will match end of word and end of line. (initially i wanted to use `(\W+|$)` or `(?:\W+|$)`)

In the past it also was matched with end boundary - https://github.com/elgatito/script.elementum.burst/commit/67e7e0d86d7b4cf5510ed661d92c59d1669d0adf#diff-78cc99018f5874a1a9641c20d0e5b1d595c3ffa33528e7c7c49fad8e111a0268L68
e.g. it was `_ts_` where `_` was replaced by space and then searched in title.

I tested it with several torrents - i do not see any regression, but i see previously incorrectly blocked results.

Online regexp tests: https://regex101.com/r/nOI6P7/1
before:
![Screenshot 2024-09-25 at 14-24-43 regex101 build test and debug regex](https://github.com/user-attachments/assets/dbffe842-2f16-48cc-a0fa-36ad8026c19f)
after:
![Screenshot 2024-09-25 at 14-25-00 regex101 build test and debug regex](https://github.com/user-attachments/assets/a8bdcc2f-db76-4f91-9f90-6ac55cee5ce3)

so now it does not match words like "camera" and "tsumani".

---

*there is still small issue with filters line `trailer` and `line`, since those are quite common words, but i guess we can't fix this easily.*