### PR TITLE
Disable magnetdl as of 02.10.2024

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -1434,7 +1434,7 @@
         "anime_query": "",
         "base_url": "https://www.magnetdl.com/FIRSTLETTER/QUERYEXTRA/",
         "color": "FF017BD4",
-        "enabled": true,
+        "enabled": false,
         "general_extra": "",
         "general_keywords": "{title:original}",
         "general_query": "",
@@ -1456,7 +1456,7 @@
             "size": "item(tag='td', order=6)",
             "torrent": "item(tag='a', attribute='href')"
         },
-        "predefined": true,
+        "predefined": false,
         "private": false,
         "season_extra": "",
         "season_extra2": "",

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -55,10 +55,6 @@
       <setting id="bitsearch_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="bitsearch_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
-    <setting label="[B]MagnetDL[/B]   [COLOR gray][$ADDON[script.elementum.burst 32111]][/COLOR]" id="use_magnetdl" type="bool" default="true" />
-      <setting id="magnetdl_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
-      <setting id="magnetdl_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
-
     <setting label="[B]AniLibria[/B]   [COLOR gray][$ADDON[script.elementum.burst 32114]][/COLOR]" id="use_anilibria" type="bool" default="false" />
       <setting id="anilibria_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="anilibria_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />


### PR DESCRIPTION
It is dead since June 30 2024 and there is no official reincarnation of this tracker.
https://torrentfreak.com/torrent-site-magnetdl-suffers-extended-downtime-240630/