### PR TITLE
Remove unused "id" field from parser and api_format

### DIFF
--- a/burst/provider.py
+++ b/burst/provider.py
@@ -42,7 +42,7 @@ def generate_payload(provider, generator, filtering, verify_name=True, verify_si
     definition = definitions[provider]
     definition = get_alias(definition, get_setting("%s_alias" % provider))
 
-    for id, name, info_hash, uri, size, seeds, peers in generator:
+    for name, info_hash, uri, size, seeds, peers in generator:
         size = clean_size(size)
         # uri, info_hash = clean_magnet(uri, info_hash)
         v_name = name if verify_name else filtering.title
@@ -53,7 +53,6 @@ def generate_payload(provider, generator, filtering, verify_name=True, verify_si
             sort_balance = (sort_seeds + 1) * 3 * sort_resolution
 
             results.append({
-                "id": id,
                 "name": name,
                 "uri": uri,
                 "info_hash": info_hash,


### PR DESCRIPTION
fixes https://github.com/elgatito/script.elementum.burst/issues/417

we can merge this or leave old code as is. up to your liking.

story:
`id` field looks unused. [it was added 3 years ago](https://github.com/elgatito/script.elementum.burst/commit/5945e3d886340c4e226c710609cc4a56bc423fa7), but then i do not see any usage neither in burst or elementum.
for duplicates `hash` is used - https://github.com/elgatito/script.elementum.burst/blob/0de57c95170915e837ec63c42190675ec348562f/burst/filtering.py#L810
in elementum there is no such field for TorrentFile - https://github.com/elgatito/elementum/blame/master/bittorrent/torrent_file.go#L35

maybe it was supposed to be used to find duplicates, but then this idea was abandoned.

after removing all lines added in the commit above - nothing changed in terms of search.