### PR TITLE
Make bt4g predefined, make bitsearch not predefined.

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -405,7 +405,7 @@
             "size": "item.find_once(tag='div', select=('class', 'stats')).find_once(tag='div', order=2).text()",
             "torrent": "item(tag='a', select=('class', 'dl-magnet'), attribute='href', order=1)"
         },
-        "predefined": true,
+        "predefined": false,
         "private": false,
         "season_extra": "",
         "season_extra2": "",
@@ -452,7 +452,7 @@
             "size": "item(tag='b', select=('class', 'red-pill'))",
             "torrent": "'https://bt4gprx.com%s' % item(tag='a', attribute='href', order=1)"
         },
-        "predefined": false,
+        "predefined": true,
         "private": false,
         "season_extra": "",
         "season_keywords": "{title:original:en} s{season:2}",

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -51,9 +51,9 @@
       <setting id="1337x_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="1337x_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
-    <setting label="[B]BitSearch[/B]   [COLOR gray][$ADDON[script.elementum.burst 32111]][/COLOR]" id="use_bitsearch" type="bool" default="true" />
-      <setting id="bitsearch_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
-      <setting id="bitsearch_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
+    <setting label="[B]BT4G[/B]   [COLOR gray][$ADDON[script.elementum.burst 32111]][/COLOR]" id="use_bt4g" type="bool" default="true" />
+      <setting id="bt4g_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="bt4g_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="[B]AniLibria[/B]   [COLOR gray][$ADDON[script.elementum.burst 32114]][/COLOR]" id="use_anilibria" type="bool" default="false" />
       <setting id="anilibria_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
@@ -63,9 +63,9 @@
       <setting id="animaunt_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
       <setting id="animaunt_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
-    <setting label="[B]BT4G[/B]   [COLOR gray][$ADDON[script.elementum.burst 32111]][/COLOR]" id="use_bt4g" type="bool" default="false" />
-      <setting id="bt4g_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
-      <setting id="bt4g_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
+    <setting label="[B]BitSearch[/B]   [COLOR gray][$ADDON[script.elementum.burst 32111]][/COLOR]" id="use_bitsearch" type="bool" default="false" />
+      <setting id="bitsearch_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />
+      <setting id="bitsearch_contains" type="enum" label="32080" subsetting="true" lvalues="32081|32082|32083" visible="eq(-2,true)" />
 
     <setting label="[B]Cpasbien[/B]   [COLOR gray][$ADDON[script.elementum.burst 32113]][/COLOR]" id="use_cpasbien" type="bool" default="false" />
       <setting id="cpasbien_alias" label="32077" type="text" default="" subsetting="true" visible="eq(-1,true)" />


### PR DESCRIPTION
looks like currently bitsearch has stale data. also looks like torrentz is just a mirror of bitsearch, but it does not matter.
bt4g looks like good replacement of magnetdl.