### PR TITLE
Fix multiline torrent name

### DIFF
--- a/burst/burst.py
+++ b/burst/burst.py
@@ -556,7 +556,7 @@ def extract_from_api(provider, client):
             size = re.findall("\\b(\\d+(?:\\.\\d+)? [MG]B)\\b", title)[0]
 
         if 'name' in api_format:
-            name = get_nested_value(result, api_format['name'], "").split()[0]
+            name = get_nested_value(result, api_format['name'], "").replace('\n', ' ').replace('\r', '')
         if 'description' in api_format:
             if name:
                 name += ' '

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -3595,6 +3595,7 @@
         "api_format": {
             "info_hash": "hash",
             "name": "title_long",
+            "description": "type",
             "peers": "peers",
             "quality": "quality",
             "results": "data.movies",


### PR DESCRIPTION
- Fix multiline torrent name.
2nd line is considered as texture by kodi internals, i guess:
`debug <general>: [Warning] CGUITextureManager::GetTexturePath: could not find texture ' 1168  1.87 GB  1337x'`
so issues #486 was not because of "smiles", but because of 2nd line.
fixes #488

- YTS: add "type" to torrent name.

