### PR TITLE
Change API address for YTS

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -3604,7 +3604,7 @@
             "subresults": "torrents",
             "torrent": "url"
         },
-        "base_url": "https://yts.lt/api/v2/list_movies.json?query_term=QUERY&sort_by=seeds&order_by=desc",
+        "base_url": "https://movies-api.accel.li/api/v2/list_movies.json?query_term=QUERY&sort_by=seeds&order_by=desc",
         "color": "FF6AC045",
         "enabled": true,
         "general_extra": null,

--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -3604,7 +3604,7 @@
             "subresults": "torrents",
             "torrent": "url"
         },
-        "base_url": "https://yts.mx/api/v2/list_movies.json?query_term=QUERY&sort_by=seeds&order_by=desc",
+        "base_url": "https://yts.lt/api/v2/list_movies.json?query_term=QUERY&sort_by=seeds&order_by=desc",
         "color": "FF6AC045",
         "enabled": true,
         "general_extra": null,

--- a/scripts/antizapret_test.py
+++ b/scripts/antizapret_test.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         "thepiratebay10.xyz",
         "1337x.to",
         "glodls.to",
-        "yts.mx",
+        "yts.lt",
         "eztvx.to",
         "bt4gprx.com",
         "bitsearch.to",


### PR DESCRIPTION
fixes https://github.com/elgatito/plugin.video.elementum/issues/1161

сначала они переехали на .lt, но пока pr висел - переехали на .bz, а теперь предлагают новый адрес API

<img width="1785" height="268" alt="Screenshot_20260222_141840" src="https://github.com/user-attachments/assets/8d08df82-7aa6-47b5-b6e3-653ec1432a20" />
